### PR TITLE
Improve version check readability by not using too more if_else

### DIFF
--- a/rplugin/python3/defx/defx.py
+++ b/rplugin/python3/defx/defx.py
@@ -35,12 +35,5 @@ class Defx(object):
         Checks Python version.
         Python3.6.1+ is required for defx.
         """
-        version = sys.version_info
-        if version.major < 3:
-            return True
-        if version.major == 3 and version.minor < 6:
-            return True
-        if version.major == 3 and version.minor == 6 and version.micro < 1:
-            return True
-
-        return False
+        v = sys.version_info
+        return (v.major, v.minor, v.micro) < (3, 6, 1)


### PR DESCRIPTION
According [this][1], we can use tuple comparison to improve `version_check()` readability.
For example,  (3,6,0) < (3,6,1)


[1]: https://stackoverflow.com/questions/5292303/how-does-tuple-comparison-work-in-python