### PR TITLE
Create parent directories from new file name if provided and add remove action

### DIFF
--- a/doc/defx.txt
+++ b/doc/defx.txt
@@ -94,7 +94,7 @@ new_directory 					*defx-action-new_directory*
 		Create a new directory.
 
 new_file 						*defx-action-new_file*
-		Create a new file.
+		Create a new file and directory if provided.
 
 open							*defx-action-open*
 		Open the file.

--- a/doc/defx.txt
+++ b/doc/defx.txt
@@ -101,6 +101,8 @@ open							*defx-action-open*
 
 toggle_select					*defx-action-toggle_select*
 		Toggle the cursor candidate select.
+remove						      *defx-action-remove*
+		Delete the file/directory under cursor or from selected list.
 
 ------------------------------------------------------------------------------
 OPTIONS							*defx-options*
@@ -128,6 +130,8 @@ EXAMPLES						*defx-examples*
 	  \ defx#do_action('new_directory')
 	  nnoremap <silent><buffer><expr> N
 	  \ defx#do_action('new_file')
+	  nnoremap <silent><buffer><expr> D
+	  \ defx#do_action('remove')
 	  nnoremap <silent><buffer><expr> h
 	  \ defx#do_action('cd', ['..'])
 	  nnoremap <silent><buffer><expr> ~

--- a/rplugin/python3/defx/action.py
+++ b/rplugin/python3/defx/action.py
@@ -72,13 +72,17 @@ def _new_directory(view: View, defx: Defx, context: Context) -> None:
 
 def _new_file(view: View, defx: Defx, context: Context) -> None:
     """
-    Create a new file.
+    Create a new file and it's parent directories.
     """
     filename = cwd_input(view._vim, defx._cwd,
                          'Please input a new filename: ', '', 'file')
     if os.path.exists(filename):
         error(view._vim, '{} is already exists'.format(filename))
         return
+
+    dirname = os.path.dirname(filename)
+    if not os.path.exists(dirname):
+        os.makedirs(dirname)
 
     with open(filename, 'w') as f:
         f.write('')

--- a/rplugin/python3/defx/action.py
+++ b/rplugin/python3/defx/action.py
@@ -7,10 +7,11 @@
 from enum import auto, IntFlag
 import os
 import typing
+import shutil
 
 from defx.context import Context
 from defx.defx import Defx
-from defx.util import error, cwd_input, expand
+from defx.util import error, cwd_input, expand, confirm
 from defx.view import View
 
 
@@ -99,6 +100,23 @@ def _toggle_select(view: View, defx: Defx, context: Context) -> None:
     view.redraw()
 
 
+def _remove(view: View, defx: Defx, context: Context) -> None:
+    """
+    Delete the file or directory.
+    """
+    if not confirm(view._vim, 'Are you sure you want to delete this node?'):
+        return
+
+    for target in context.targets:
+        path = target['action__path']
+
+        if os.path.isdir(path):
+            shutil.rmtree(path)
+        else:
+            os.remove(path)
+    view.redraw(True)
+
+
 class ActionAttr(IntFlag):
     REDRAW = auto()
     NONE = 0
@@ -115,4 +133,5 @@ DEFAULT_ACTIONS = {
     'new_directory': ActionTable(func=_new_directory),
     'new_file': ActionTable(func=_new_file),
     'toggle_select': ActionTable(func=_toggle_select),
+    'remove': ActionTable(func=_remove),
 }

--- a/rplugin/python3/defx/util.py
+++ b/rplugin/python3/defx/util.py
@@ -41,3 +41,11 @@ def cwd_input(vim: Nvim, cwd: str, prompt: str,
 
     vim.command('lcd {}'.format(save_cwd))
     return filename
+
+
+def confirm(vim: Nvim, question: str) -> bool:
+    """
+    Confirm action
+    """
+    option: int = vim.call('confirm', question, '&Yes\n&No\n&Cancel')
+    return option is 1


### PR DESCRIPTION
Hi,

This PR contains two things:

1. Creating parent directories of a new file name.
This allows providing file name like `myfolder/newfolder/newfile.py`, and action will take care of creating any parent folders, in this case `myfolder/newfolder`, if they doesn't exist.

2. Removing files/directories.
I added confirm to make sure someone didn't press remove action accidentally. I know you planned to add this, but i wanted to help, and this is something that i'm really missing at this moment.