### PR TITLE
Do not wrap text in defx and do not list it in buffers.

### DIFF
--- a/rplugin/python3/defx/view.py
+++ b/rplugin/python3/defx/view.py
@@ -37,6 +37,7 @@ class View(object):
             'silent keepalt edit', '[defx]')
 
         self._vim.current.window.options['list'] = False
+        self._vim.current.window.options['wrap'] = False
         self._options = self._vim.current.buffer.options
         self._options['buftype'] = 'nofile'
         self._options['swapfile'] = False


### PR DESCRIPTION
Wrapping really messes up layout, so it must be disabled.
Also, there's no reason to list defx buffer in the buffers list, it can be opened with command at any time.