### PR TITLE
Fix path completion on command mode

### DIFF
--- a/autoload/defx/util.vim
+++ b/autoload/defx/util.vim
@@ -156,10 +156,12 @@ function! defx#util#complete(arglead, cmdline, cursorpos) abort
     " Add "-no-" option names completion.
     let _ += map(copy(bool_options), "'-no-' . tr(v:val, '_', '-')")
   else
+    let arglead = expand(a:arglead)
     " Path names completion.
     let files = filter(glob(a:arglead . '*', v:true, v:true),
-          \ 'stridx(tolower(v:val), tolower(a:arglead)) == 0')
+          \ 'stridx(tolower(v:val), tolower(arglead)) == 0')
     let files = filter(files, 'isdirectory(v:val)')
+    call map(files, 's:substitute_path_separator(expand(v:val))')
     if a:arglead =~# '^\~'
       let home_pattern = '^'.
             \ s:substitute_path_separator(expand('~')).'/'


### PR DESCRIPTION
Fix a problem that path completion doesn't work when argument has "~/" or "../" on both Ubuntu 16.04 and Windows 10.
