### PR TITLE
Import Nvim type definition from pynvim or neovim

### DIFF
--- a/rplugin/python3/defx/base/column.py
+++ b/rplugin/python3/defx/base/column.py
@@ -7,7 +7,7 @@
 from abc import abstractmethod
 
 from defx.context import Context
-from neovim import Nvim
+from defx.util import Nvim
 
 
 class Base:

--- a/rplugin/python3/defx/base/source.py
+++ b/rplugin/python3/defx/base/source.py
@@ -8,7 +8,7 @@ import typing
 
 from abc import abstractmethod
 from defx.context import Context
-from neovim import Nvim
+from defx.util import Nvim
 from pathlib import Path
 
 

--- a/rplugin/python3/defx/column/filename.py
+++ b/rplugin/python3/defx/column/filename.py
@@ -6,7 +6,7 @@
 
 from defx.base.column import Base
 from defx.context import Context
-from neovim import Nvim
+from defx.util import Nvim
 
 
 class Column(Base):

--- a/rplugin/python3/defx/column/mark.py
+++ b/rplugin/python3/defx/column/mark.py
@@ -6,7 +6,7 @@
 
 from defx.base.column import Base
 from defx.context import Context
-from neovim import Nvim
+from defx.util import Nvim
 
 import os
 

--- a/rplugin/python3/defx/column/type.py
+++ b/rplugin/python3/defx/column/type.py
@@ -6,7 +6,7 @@
 
 from defx.base.column import Base
 from defx.context import Context
-from neovim import Nvim
+from defx.util import Nvim
 
 import re
 

--- a/rplugin/python3/defx/defx.py
+++ b/rplugin/python3/defx/defx.py
@@ -9,7 +9,7 @@ import typing
 
 from defx.source.file import Source as File
 from defx.context import Context
-from neovim import Nvim
+from defx.util import Nvim
 from pathlib import Path
 
 

--- a/rplugin/python3/defx/rplugin.py
+++ b/rplugin/python3/defx/rplugin.py
@@ -8,8 +8,7 @@ import typing
 
 from defx.clipboard import Clipboard
 from defx.view import View
-from defx.util import error
-from neovim import Nvim
+from defx.util import error, Nvim
 
 
 class Rplugin:

--- a/rplugin/python3/defx/source/file.py
+++ b/rplugin/python3/defx/source/file.py
@@ -9,8 +9,7 @@ import typing
 
 from defx.base.source import Base
 from defx.context import Context
-from defx.util import error, readable, safe_call
-from neovim import Nvim
+from defx.util import error, readable, safe_call, Nvim
 
 
 class Source(Base):

--- a/rplugin/python3/defx/util.py
+++ b/rplugin/python3/defx/util.py
@@ -7,9 +7,13 @@
 import importlib.util
 import os
 import typing
-
-from neovim import Nvim
 from pathlib import Path
+
+from importlib import find_loader
+if find_loader('pynvim'):
+    from pynvim import Nvim
+else:
+    from neovim import Nvim
 
 
 def error(vim: Nvim, expr: typing.Any) -> None:

--- a/rplugin/python3/defx/view.py
+++ b/rplugin/python3/defx/view.py
@@ -4,7 +4,6 @@
 # License: MIT license
 # ============================================================================
 
-from neovim import Nvim
 import time
 import typing
 from pathlib import Path
@@ -13,7 +12,7 @@ from defx.base.column import Base as Column
 from defx.clipboard import Clipboard
 from defx.context import Context
 from defx.defx import Defx
-from defx.util import error, import_plugin, safe_call
+from defx.util import error, import_plugin, safe_call, Nvim
 
 
 class View(object):


### PR DESCRIPTION
I have this error when I execute UpdateRemotePlugins.

```
Encountered ModuleNotFoundError loading plugin at /home/h-michael/.cache/dein/repos/github.com/Shougo/defx.nvim/rplugin/python3/defx: No module named 'neovim'
Traceback (most recent call last):
  File "/home/h-michael/.local/lib/python3.7/site-packages/pynvim/plugin/host.py", line 135, in _load
    module = imp.load_module(name, file, pathname, descr)
  File "/usr/lib/python3.7/imp.py", line 244, in load_module
    return load_package(name, filename)
  File "/usr/lib/python3.7/imp.py", line 216, in load_package
    return _load(spec)
  File "<frozen importlib._bootstrap>", line 696, in _load
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
ModuleNotFoundError: No module named 'neovim'
```

This PR solves above problem.