### PR TITLE
Import Nvim typedef from defx.util for Denite source

### DIFF
--- a/rplugin/python3/denite/source/defx/history.py
+++ b/rplugin/python3/denite/source/defx/history.py
@@ -4,8 +4,8 @@
 # License: MIT license
 # ============================================================================
 
-from neovim import Nvim
 from ..base import Base
+from defx.util import Nvim
 
 
 class Source(Base):


### PR DESCRIPTION
For fixing this error.
```
[denite] Traceback (most recent call last):
[denite]   File "/home/h-michael/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3/denite/__init__.py", line 38, in start
[denite]     return ui.start(args[0], args[1])
[denite]   File "/home/h-michael/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3/denite/ui/default.py", line 70, in start
[denite]     self._start(context['sources_queue'][0], context)
[denite]   File "/home/h-michael/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3/denite/ui/default.py", line 120, in _start
[denite]     self.init_denite()
[denite]   File "/home/h-michael/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3/denite/ui/default.py", line 635, in init_denite
[denite]     self._denite.start(self._context)
[denite]   File "/home/h-michael/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3/denite/denite.py", line 39, in start
[denite]     self._load_sources(context)
[denite]   File "/home/h-michael/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3/denite/denite.py", line 321, in _load_sources
[denite]     for Source, path, _ in rplugins:
[denite]   File "/home/h-michael/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3/denite/util.py", line 253, in import_rplugins
[denite]     spec.loader.exec_module(module)
[denite]   File "<frozen importlib._bootstrap_external>", line 728, in exec_module
[denite]   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
[denite]   File "/home/h-michael/.cache/dein/repos/github.com/Shougo/defx.nvim/rplugin/python3/denite/source/defx/history.py", line 7, in <module>
[denite]     from neovim import Nvim
[denite] ModuleNotFoundError: No module named 'neovim'
```