### PR TITLE
add -save option.

### DIFF
--- a/autoload/defx/init.vim
+++ b/autoload/defx/init.vim
@@ -106,6 +106,7 @@ function! defx#init#_user_options() abort
         \ 'toggle': v:false,
         \ 'winheight': 0,
         \ 'winwidth': 0,
+        \ 'save': v:false,
         \ }
 endfunction
 function! s:internal_options() abort
@@ -118,5 +119,9 @@ function! defx#init#_context(user_context) abort
   let context = s:internal_options()
   call extend(context, defx#init#_user_options())
   call extend(context, a:user_context)
+  if context['save']==v:true
+    write
+  endif
+  unlet context.save
   return context
 endfunction

--- a/doc/defx.txt
+++ b/doc/defx.txt
@@ -259,6 +259,13 @@ OPTIONS							*defx-options*
 
 		Default: false
 
+							*defx-option-save*
+-save
+		Save when opning defx on unsaved files.
+		This option can be used to prevent discarding unsaved changes
+		by mistake.
+		Default: false
+
 							*defx-option-search*
 -search={path}
 		Search the {path}.


### PR DESCRIPTION
if you use -save option like below,
:Defx -save -split=no
defx will save before discarding your unsaved changes.