### PR TITLE
Enable to custom length of marks

### DIFF
--- a/rplugin/python3/defx/column/mark.py
+++ b/rplugin/python3/defx/column/mark.py
@@ -40,7 +40,7 @@ class Column(Base):
         return icon
 
     def length(self, context: Context) -> int:
-        return self.vars['length']
+        return typing.cast(int, self.vars['length'])
 
     def highlight(self) -> None:
         for icon, highlight in {

--- a/rplugin/python3/defx/column/mark.py
+++ b/rplugin/python3/defx/column/mark.py
@@ -23,11 +23,12 @@ class Column(Base):
             'selected_icon': '*',
             'readonly_icon': 'X',
             'root_icon': '-',
+            'length': 1,
         }
 
     def get(self, context: Context,
             candidate: typing.Dict[str, typing.Any]) -> str:
-        icon: str = ' '
+        icon: str = ' ' * self.vars['length']
         if candidate.get('is_selected', False):
             icon = self.vars['selected_icon']
         elif candidate.get('is_root', False):
@@ -39,7 +40,7 @@ class Column(Base):
         return icon
 
     def length(self, context: Context) -> int:
-        return 1
+        return self.vars['length']
 
     def highlight(self) -> None:
         for icon, highlight in {


### PR DESCRIPTION
I want to use some double-bytes icons for marks from [Nerd Fonts][], for example.  But in the latest master, marks are considered to have one char.

[Nerd Fonts]: https://nerdfonts.com

So when set to this,

```vim
  call defx#custom#column('mark', {
        \ 'directory_icon': nr2char(0xe5ff),
        \ 'readonly_icon': nr2char(0xe0a2),
        \ 'root_icon': nr2char(0xe5fe),
        \ 'selected_icon': '✓',
        \ })
```

It seems tight a bit.

<img width="676" alt="2019-01-17 12 30 12" src="https://user-images.githubusercontent.com/1239245/51293937-2b725900-1a54-11e9-85a0-36939e41aafc.png">

This patch enables to set length for marks and solve this.

```vim
  call defx#custom#column('mark', {
        \ 'directory_icon': nr2char(0xe5ff) . ' ',
        \ 'readonly_icon': nr2char(0xe0a2) . ' ',
        \ 'root_icon': nr2char(0xe5fe) . ' ',
        \ 'selected_icon': '✓ ',
        \ 'length': 2,
        \ })
```

<img width="676" alt="2019-01-17 12 30 57" src="https://user-images.githubusercontent.com/1239245/51293978-4d6bdb80-1a54-11e9-8075-7357ee41bef2.png">
