### PR TITLE
Fixed tree indentation coloring.

### DIFF
--- a/rplugin/python3/defx/column/filename.py
+++ b/rplugin/python3/defx/column/filename.py
@@ -54,7 +54,7 @@ class Column(Base):
     def highlight_commands(self) -> typing.List[str]:
         commands: typing.List[str] = []
         commands.append(
-            r'syntax match {0}_{1} /.*\// contained containedin={0}'.format(
+            r'syntax match {0}_{1} /\S.*\// contained containedin={0}'.format(
                 self.syntax_name, 'directory'))
         commands.append(
             (r'syntax match {0}_{1} /\%{2}c\..*/' +


### PR DESCRIPTION
As defx now has tree features, indentation may be inserted before directories.
When using colorscheme with background color, this caused indentation to be painted the same as directory.
![screenshot from 2019-03-08 03-24-16](https://user-images.githubusercontent.com/30687489/54016979-a00f6d00-4152-11e9-9cef-5b2ddce5dd95.png)

This PR fixes the problem as for directory.
![screenshot from 2019-03-08 03-25-44](https://user-images.githubusercontent.com/30687489/54017000-aef61f80-4152-11e9-8bd5-221d3cf1b70c.png)
