### PR TITLE
Changed to not resolve symbolic links in the given directory path

### DIFF
--- a/rplugin/python3/defx/defx.py
+++ b/rplugin/python3/defx/defx.py
@@ -46,7 +46,7 @@ class Defx(object):
         error(self._vim, expr)
 
     def cd(self, path: str) -> None:
-        self._cwd = str(Path(self._cwd).joinpath(path).resolve())
+        self._cwd = str(Path(self._cwd).joinpath(path))
 
         if self._context.auto_cd:
             cd(self._vim, path)


### PR DESCRIPTION
When working inside a project that is inside a sym link, and then opening defx and then opening another file in this project, defx will resolve all the sym links in the path.  It is better to use the same path (with the sym links)