### PR TITLE
Improve the action registration mechanism and more

### DIFF
--- a/autoload/defx/init.vim
+++ b/autoload/defx/init.vim
@@ -95,7 +95,7 @@ function! defx#init#_user_options() abort
         \ 'auto_cd': v:false,
         \ 'auto_recursive_level': 0,
         \ 'buffer_name': 'default',
-        \ 'columns': 'mark:filename:type',
+        \ 'columns': 'mark:indent:basic:filename:type',
         \ 'direction': '',
         \ 'ignored_files': '.*',
         \ 'listed': v:false,

--- a/doc/defx.txt
+++ b/doc/defx.txt
@@ -395,7 +395,7 @@ OPTIONS							*defx-options*
 							*defx-option-columns*
 -columns={columns1:columns2,...}
 		Specify defx columns.
-		Default: "mark:filename:type"
+		Default: "mark:indent:basic:filename:type"
 
 						*defx-option-direction*
 -direction={direction}
@@ -518,21 +518,27 @@ COLUMNS							*defx-columns*
 filename	File name.
 
 		variables:
-		directory_icon	  the closed directory icon
-				  (default: "+")
-		indent		  the tree indentation
-				  (default: " ")
 		min_width	  the minimum width of a defx buffer
 				  (default: 40)
 		max_width	  the maximum width of a defx buffer
 				  (default: 100)
+		root_marker_highlight
+				the root marker highlight
+				  (default: "Constant")
+
+							*defx-column-basic*
+basic		Basic icon.
+
+		variables:
+		directory_icon	  the closed directory icon
+				  (default: "+")
 		opened_icon	  the opened directory icon
 				  (default: "-")
 		root_icon	  the root directory icon
 				  (default: " ")
-		root_marker_highlight
-				the root marker highlight
-				  (default: "Constant")
+
+							*defx-column-indent*
+indent		Tree indentation (default: " ")
 
 							*defx-column-mark*
 mark		File selected mark.

--- a/rplugin/python3/defx/column/filename.py
+++ b/rplugin/python3/defx/column/filename.py
@@ -18,24 +18,17 @@ class Column(Base):
 
         self.name = 'filename'
         self.vars = {
-            'directory_icon': '+',
-            'indent': ' ',
             'min_width': 40,
             'max_width': 100,
-            'opened_icon': '-',
-            'root_icon': ' ',
             'root_marker_highlight': 'Constant',
         }
 
         self._current_length = 0
         self._syntaxes = [
             'directory',
-            'directory_icon',
             'hidden',
             'marker',
-            'opened_icon',
             'root',
-            'root_icon',
         ]
         self._context: Context = Context()
 
@@ -44,17 +37,7 @@ class Column(Base):
 
     def get(self, context: Context,
             candidate: typing.Dict[str, typing.Any]) -> str:
-        if candidate['is_opened_tree']:
-            icon = self.vars['opened_icon']
-        elif candidate['is_root']:
-            icon = self.vars['root_icon']
-        elif candidate['is_directory']:
-            icon = self.vars['directory_icon']
-        else:
-            icon = ' '
-        return self._truncate(
-            self.vars['indent'] * candidate['level'] +
-            icon + ' ' + candidate['word'])
+        return self._truncate(candidate['word'])
 
     def length(self, context: Context) -> int:
         max_fnamewidth = max([self._strwidth(x['word'])
@@ -69,19 +52,6 @@ class Column(Base):
 
     def highlight_commands(self) -> typing.List[str]:
         commands: typing.List[str] = []
-        for icon, highlight in {
-                'directory': 'Special',
-                'opened': 'Special',
-                'root': 'Identifier',
-        }.items():
-            commands.append(
-                ('syntax match {0}_{1}_icon /[{2}]/ ' +
-                 'contained containedin={0}_directory').format(
-                    self.syntax_name, icon, self.vars[icon + '_icon']))
-            commands.append(
-                'highlight default link {}_{}_icon {}'.format(
-                    self.syntax_name, icon, highlight))
-
         commands.append(
             r'syntax match {0}_{1} /\S.*[\\\/]/ '
             'contained containedin={0}'.format(

--- a/rplugin/python3/defx/column/icon.py
+++ b/rplugin/python3/defx/column/icon.py
@@ -1,0 +1,65 @@
+# ============================================================================
+# FILE: icon.py
+# AUTHOR: GuoPan Zhao <zgpio@qq.com>
+# License: MIT license
+# ============================================================================
+
+from defx.base.column import Base
+from defx.context import Context
+from defx.util import Nvim
+
+import typing
+
+
+class Column(Base):
+
+    def __init__(self, vim: Nvim) -> None:
+        super().__init__(vim)
+
+        self.name = 'basic'
+        self.vars = {
+            'length': 1,
+            'directory_icon': '+',
+            'opened_icon': '-',
+            'root_icon': ' ',
+        }
+        self._syntaxes = [
+            'directory_icon',
+            'opened_icon',
+            'root_icon',
+        ]
+
+    def get(self, context: Context,
+            candidate: typing.Dict[str, typing.Any]) -> str:
+        if candidate['is_opened_tree']:
+            icon = self.vars['opened_icon']
+        elif candidate['is_root']:
+            icon = self.vars['root_icon']
+        elif candidate['is_directory']:
+            icon = self.vars['directory_icon']
+        else:
+            icon = ' '
+        return icon
+
+    def length(self, context: Context) -> int:
+        return typing.cast(int, self.vars['length'])
+
+    def syntaxes(self) -> typing.List[str]:
+        return [self.syntax_name + '_' + x for x in self._syntaxes]
+
+    def highlight_commands(self) -> typing.List[str]:
+        commands: typing.List[str] = []
+        for icon, highlight in {
+                'directory': 'Special',
+                'opened': 'Special',
+                'root': 'Identifier',
+        }.items():
+            commands.append(
+                ('syntax match {0}_{1}_icon /[{2}]/ ' +
+                 'contained containedin={0}_directory').format(
+                    self.syntax_name, icon, self.vars[icon + '_icon']))
+            commands.append(
+                'highlight default link {}_{}_icon {}'.format(
+                    self.syntax_name, icon, highlight))
+
+        return commands

--- a/rplugin/python3/defx/column/indent.py
+++ b/rplugin/python3/defx/column/indent.py
@@ -1,0 +1,28 @@
+# ============================================================================
+# FILE: indent.py
+# AUTHOR: GuoPan Zhao <zgpio@qq.com>
+# License: MIT license
+# ============================================================================
+
+from defx.base.column import Base
+from defx.context import Context
+from defx.util import Nvim
+
+import typing
+
+
+class Column(Base):
+
+    def __init__(self, vim: Nvim) -> None:
+        super().__init__(vim)
+        self.name = 'indent'
+        self._current_len = 0
+
+    def get(self, context: Context,
+            candidate: typing.Dict[str, typing.Any]) -> str:
+        indent = ' ' * candidate['level']
+        self._current_len = len(indent)
+        return indent
+
+    def length(self, context: Context) -> int:
+        return typing.cast(int, self._current_len)

--- a/rplugin/python3/defx/kind/file.py
+++ b/rplugin/python3/defx/kind/file.py
@@ -12,7 +12,7 @@ import typing
 
 from defx.action import ActionAttr
 from defx.action import ActionTable
-from defx.base.kind import Base
+from defx.base.kind import Base, action
 from defx.clipboard import ClipboardAction
 from defx.context import Context
 from defx.defx import Defx
@@ -29,28 +29,6 @@ class Kind(Base):
 
     def get_actions(self) -> typing.Dict[str, ActionTable]:
         actions = super().get_actions()
-        actions.update({
-            'cd': ActionTable(func=_cd),
-            'change_vim_cwd': ActionTable(
-                func=_change_vim_cwd, attr=ActionAttr.NO_TAGETS),
-            'check_redraw': ActionTable(
-                func=_check_redraw, attr=ActionAttr.NO_TAGETS),
-            'copy': ActionTable(func=_copy),
-            'drop': ActionTable(func=_drop),
-            'execute_command': ActionTable(
-                func=_execute_command, attr=ActionAttr.NO_TAGETS),
-            'execute_system': ActionTable(func=_execute_system),
-            'move': ActionTable(func=_move),
-            'new_directory': ActionTable(func=_new_directory),
-            'new_file': ActionTable(func=_new_file),
-            'new_multiple_files': ActionTable(func=_new_multiple_files),
-            'open': ActionTable(func=_open),
-            'open_directory': ActionTable(func=_open_directory),
-            'paste': ActionTable(func=_paste, attr=ActionAttr.NO_TAGETS),
-            'remove': ActionTable(func=_remove, attr=ActionAttr.REDRAW),
-            'remove_trash': ActionTable(func=_remove_trash),
-            'rename': ActionTable(func=_rename),
-        })
         return actions
 
 
@@ -82,6 +60,7 @@ def check_overwrite(view: View, dest: Path, src: Path) -> Path:
     return ret
 
 
+@action(name='cd')
 def _cd(view: View, defx: Defx, context: Context) -> None:
     """
     Change the current directory.
@@ -98,6 +77,7 @@ def _cd(view: View, defx: Defx, context: Context) -> None:
         view.search_file(Path(prev_cwd), defx._index)
 
 
+@action(name='change_vim_cwd', attr=ActionAttr.NO_TAGETS)
 def _change_vim_cwd(view: View, defx: Defx, context: Context) -> None:
     """
     Change the current working directory.
@@ -105,6 +85,7 @@ def _change_vim_cwd(view: View, defx: Defx, context: Context) -> None:
     cd(view._vim, defx._cwd)
 
 
+@action(name='check_redraw', attr=ActionAttr.NO_TAGETS)
 def _check_redraw(view: View, defx: Defx, context: Context) -> None:
     root = defx.get_root_candidate()
     mtime = root['action__path'].stat().st_mtime
@@ -112,6 +93,7 @@ def _check_redraw(view: View, defx: Defx, context: Context) -> None:
         view.redraw(True)
 
 
+@action(name='copy')
 def _copy(view: View, defx: Defx, context: Context) -> None:
     if not context.targets:
         return
@@ -126,6 +108,7 @@ def _copy(view: View, defx: Defx, context: Context) -> None:
     view._clipboard.candidates = context.targets
 
 
+@action(name='drop')
 def _drop(view: View, defx: Defx, context: Context) -> None:
     """
     Open like :drop.
@@ -155,6 +138,7 @@ def _drop(view: View, defx: Defx, context: Context) -> None:
             view._vim.call('defx#util#execute_path', command, str(path))
 
 
+@action(name='execute_command', attr=ActionAttr.NO_TAGETS)
 def _execute_command(view: View, defx: Defx, context: Context) -> None:
     """
     Execute the command.
@@ -172,6 +156,7 @@ def _execute_command(view: View, defx: Defx, context: Context) -> None:
     cd(view._vim, save_cwd)
 
 
+@action(name='execute_system')
 def _execute_system(view: View, defx: Defx, context: Context) -> None:
     """
     Execute the file by system associated command.
@@ -180,6 +165,7 @@ def _execute_system(view: View, defx: Defx, context: Context) -> None:
         view._vim.call('defx#util#open', str(target['action__path']))
 
 
+@action(name='move')
 def _move(view: View, defx: Defx, context: Context) -> None:
     if not context.targets:
         return
@@ -194,6 +180,7 @@ def _move(view: View, defx: Defx, context: Context) -> None:
     view._clipboard.candidates = context.targets
 
 
+@action(name='new_directory')
 def _new_directory(view: View, defx: Defx, context: Context) -> None:
     """
     Create a new directory.
@@ -224,6 +211,7 @@ def _new_directory(view: View, defx: Defx, context: Context) -> None:
     view.search_file(filename, defx._index)
 
 
+@action(name='new_file')
 def _new_file(view: View, defx: Defx, context: Context) -> None:
     """
     Create a new file and it's parent directories.
@@ -260,6 +248,7 @@ def _new_file(view: View, defx: Defx, context: Context) -> None:
     view.search_file(filename, defx._index)
 
 
+@action(name='new_multiple_files')
 def _new_multiple_files(view: View, defx: Defx, context: Context) -> None:
     """
     Create multiple files.
@@ -302,6 +291,7 @@ def _new_multiple_files(view: View, defx: Defx, context: Context) -> None:
     view.search_file(filename, defx._index)
 
 
+@action(name='open')
 def _open(view: View, defx: Defx, context: Context) -> None:
     """
     Open the file.
@@ -320,6 +310,7 @@ def _open(view: View, defx: Defx, context: Context) -> None:
         view._vim.call('defx#util#execute_path', command, str(path))
 
 
+@action(name='open_directory')
 def _open_directory(view: View, defx: Defx, context: Context) -> None:
     """
     Open the directory.
@@ -334,6 +325,7 @@ def _open_directory(view: View, defx: Defx, context: Context) -> None:
         view.cd(defx, str(path), context.cursor)
 
 
+@action(name='paste', attr=ActionAttr.NO_TAGETS)
 def _paste(view: View, defx: Defx, context: Context) -> None:
     candidate = view.get_cursor_candidate(context.cursor)
     if not candidate:
@@ -375,6 +367,7 @@ def _paste(view: View, defx: Defx, context: Context) -> None:
         view.search_file(dest, defx._index)
 
 
+@action(name='remove', attr=ActionAttr.REDRAW)
 def _remove(view: View, defx: Defx, context: Context) -> None:
     """
     Delete the file or directory.
@@ -400,6 +393,7 @@ def _remove(view: View, defx: Defx, context: Context) -> None:
             path.unlink()
 
 
+@action(name='remove_trash')
 def _remove_trash(view: View, defx: Defx, context: Context) -> None:
     """
     Delete the file or directory.
@@ -426,6 +420,7 @@ def _remove_trash(view: View, defx: Defx, context: Context) -> None:
     view.redraw(True)
 
 
+@action(name='rename')
 def _rename(view: View, defx: Defx, context: Context) -> None:
     """
     Rename the file or directory.


### PR DESCRIPTION
I think using the decorator to register an action is more flexible than manually registering the action. Just like:
```py
@action(name='cd')
def _cd(view: View, defx: Defx, context: Context) -> None:
```
I'm not sure if there is compatibility with such a change, I just did some manual testing,
and the `action_table` variable can be hidden from the outside.

-----------------------------

In fact, `tree indent` can also be treated as a `column`.
After abstract `indent` to a `column`, users can customize the location of the indent,
e.g. when combine with [defx-icons](https://github.com/kristijanhusak/defx-icons), 
using command `:Defx -columns=mark:indent:icons:filename:type`, 
this looks more reasonable and great.

![image](https://user-images.githubusercontent.com/19503791/55635361-10151f80-57f3-11e9-8330-bffab74e5ba5.png)

Unfortunately, I can't fix the highlight, using `:Defx -columns=indent:basic:filename:type`
![image](https://user-images.githubusercontent.com/19503791/55635524-8154d280-57f3-11e9-895d-4ae843d9fbfd.png)

