### PR TITLE
[WIP] Improve action register mechanism

### DIFF
--- a/rplugin/python3/defx/base/kind.py
+++ b/rplugin/python3/defx/base/kind.py
@@ -5,6 +5,7 @@
 # ============================================================================
 
 import typing
+from typing import Callable, Any
 from pathlib import Path
 
 from defx.action import ActionAttr
@@ -15,6 +16,19 @@ from defx.defx import Defx
 from defx.view import View
 from defx.util import Nvim
 
+_action_table = {}
+
+
+def action(name: str, attr: ActionAttr = ActionAttr.NONE) \
+        -> Callable[..., Callable[..., Any]]:
+    def wrapper(func: Callable[..., Any]) -> Callable[..., Any]:
+        _action_table[name] = ActionTable(func=func, attr=attr)
+
+        def inner_wrapper(*args: Any, **kwargs: Any) -> Any:
+            return func(*args, **kwargs)
+        return inner_wrapper
+    return wrapper
+
 
 class Base:
 
@@ -23,52 +37,11 @@ class Base:
         self.name = 'base'
 
     def get_actions(self) -> typing.Dict[str, ActionTable]:
-        return {
-            'call': ActionTable(
-                func=_call, attr=ActionAttr.REDRAW),
-            'check_redraw': ActionTable(
-                func=_nop, attr=ActionAttr.NO_TAGETS),
-            'clear_select_all': ActionTable(
-                func=_clear_select_all,
-                attr=ActionAttr.MARK | ActionAttr.NO_TAGETS),
-            'close_tree': ActionTable(
-                func=_close_tree, attr=ActionAttr.TREE),
-            'multi': ActionTable(func=_multi),
-            'open_tree': ActionTable(
-                func=_open_tree, attr=ActionAttr.TREE),
-            'open_tree_recursive': ActionTable(
-                func=_open_tree_recursive, attr=ActionAttr.TREE),
-            'open_or_close_tree': ActionTable(
-                func=_open_or_close_tree, attr=ActionAttr.TREE),
-            'print': ActionTable(func=_print),
-            'quit': ActionTable(
-                func=_quit, attr=ActionAttr.NO_TAGETS),
-            'redraw': ActionTable(
-                func=_redraw, attr=ActionAttr.NO_TAGETS),
-            'repeat': ActionTable(
-                func=_repeat, attr=ActionAttr.MARK),
-            'search': ActionTable(
-                func=_search, attr=ActionAttr.NO_TAGETS),
-            'toggle_columns': ActionTable(
-                func=_toggle_columns, attr=ActionAttr.REDRAW),
-            'toggle_ignored_files': ActionTable(
-                func=_toggle_ignored_files, attr=ActionAttr.REDRAW),
-            'toggle_select': ActionTable(
-                func=_toggle_select,
-                attr=ActionAttr.MARK | ActionAttr.NO_TAGETS),
-            'toggle_select_all': ActionTable(
-                func=_toggle_select_all,
-                attr=ActionAttr.MARK | ActionAttr.NO_TAGETS),
-            'toggle_select_visual': ActionTable(
-                func=_toggle_select_visual,
-                attr=ActionAttr.MARK | ActionAttr.NO_TAGETS),
-            'toggle_sort': ActionTable(
-                func=_toggle_sort,
-                attr=ActionAttr.MARK | ActionAttr.NO_TAGETS),
-            'yank_path': ActionTable(func=_yank_path),
-        }
+        return _action_table
 
 
+# <=> _call = action(name='call', attr=ActionAttr.REDRAW)(_call)
+@action(name='call', attr=ActionAttr.REDRAW)
 def _call(view: View, defx: Defx, context: Context) -> None:
     """
     Call the function.
@@ -84,12 +57,14 @@ def _call(view: View, defx: Defx, context: Context) -> None:
     view._vim.call(function, dict_context)
 
 
+@action(name='clear_select_all', attr=ActionAttr.MARK | ActionAttr.NO_TAGETS)
 def _clear_select_all(view: View, defx: Defx, context: Context) -> None:
     for candidate in [x for x in view._candidates
                       if x['_defx_index'] == defx._index]:
         candidate['is_selected'] = False
 
 
+@action(name='close_tree', attr=ActionAttr.TREE)
 def _close_tree(view: View, defx: Defx, context: Context) -> None:
     for target in context.targets:
         if target['is_directory'] and target['is_opened_tree']:
@@ -99,6 +74,7 @@ def _close_tree(view: View, defx: Defx, context: Context) -> None:
             view.search_file(target['action__path'].parent, defx._index)
 
 
+@action(name='multi')
 def _multi(view: View, defx: Defx, context: Context) -> None:
     for arg in context.args:
         args: typing.List[str]
@@ -109,21 +85,25 @@ def _multi(view: View, defx: Defx, context: Context) -> None:
         do_action(view, defx, args[0], context._replace(args=args[1:]))
 
 
+@action(name='check_redraw', attr=ActionAttr.NO_TAGETS)
 def _nop(view: View, defx: Defx, context: Context) -> None:
     pass
 
 
+@action(name='open_tree', attr=ActionAttr.TREE)
 def _open_tree(view: View, defx: Defx, context: Context) -> None:
     for target in [x for x in context.targets if x['is_directory']]:
         view.open_tree(target['action__path'], defx._index, 0)
 
 
+@action(name='open_tree_recursive', attr=ActionAttr.TREE)
 def _open_tree_recursive(view: View, defx: Defx, context: Context) -> None:
     level = int(context.args[0]) if context.args else 20
     for target in [x for x in context.targets if x['is_directory']]:
         view.open_tree(target['action__path'], defx._index, level)
 
 
+@action(name='open_or_close_tree', attr=ActionAttr.TREE)
 def _open_or_close_tree(view: View, defx: Defx, context: Context) -> None:
     for target in context.targets:
         if not target['is_directory'] or target['is_opened_tree']:
@@ -132,23 +112,28 @@ def _open_or_close_tree(view: View, defx: Defx, context: Context) -> None:
             _open_tree(view, defx, context._replace(targets=[target]))
 
 
+@action(name='print')
 def _print(view: View, defx: Defx, context: Context) -> None:
     for target in context.targets:
         view.print_msg(str(target['action__path']))
 
 
+@action(name='quit', attr=ActionAttr.NO_TAGETS)
 def _quit(view: View, defx: Defx, context: Context) -> None:
     view.quit()
 
 
+@action(name='redraw', attr=ActionAttr.NO_TAGETS)
 def _redraw(view: View, defx: Defx, context: Context) -> None:
     view.redraw(True)
 
 
+@action(name='repeat', attr=ActionAttr.MARK)
 def _repeat(view: View, defx: Defx, context: Context) -> None:
     do_action(view, defx, view._prev_action, context)
 
 
+@action(name='search', attr=ActionAttr.NO_TAGETS)
 def _search(view: View, defx: Defx, context: Context) -> None:
     if not context.args or not context.args[0]:
         return
@@ -169,6 +154,7 @@ def _search(view: View, defx: Defx, context: Context) -> None:
     view.search_file(Path(search_path), defx._index)
 
 
+@action(name='toggle_columns', attr=ActionAttr.REDRAW)
 def _toggle_columns(view: View, defx: Defx, context: Context) -> None:
     """
     Toggle the current columns.
@@ -183,10 +169,12 @@ def _toggle_columns(view: View, defx: Defx, context: Context) -> None:
     view._init_columns(columns)
 
 
+@action(name='toggle_ignored_files', attr=ActionAttr.REDRAW)
 def _toggle_ignored_files(view: View, defx: Defx, context: Context) -> None:
     defx._enabled_ignored_files = not defx._enabled_ignored_files
 
 
+@action(name='toggle_select', attr=ActionAttr.MARK | ActionAttr.NO_TAGETS)
 def _toggle_select(view: View, defx: Defx, context: Context) -> None:
     candidate = view.get_cursor_candidate(context.cursor)
     if not candidate:
@@ -195,6 +183,7 @@ def _toggle_select(view: View, defx: Defx, context: Context) -> None:
     candidate['is_selected'] = not candidate['is_selected']
 
 
+@action(name='toggle_select_all', attr=ActionAttr.MARK | ActionAttr.NO_TAGETS)
 def _toggle_select_all(view: View, defx: Defx, context: Context) -> None:
     for candidate in [x for x in view._candidates
                       if not x['is_root'] and
@@ -202,6 +191,8 @@ def _toggle_select_all(view: View, defx: Defx, context: Context) -> None:
         candidate['is_selected'] = not candidate['is_selected']
 
 
+@action(name='toggle_select_visual',
+        attr=ActionAttr.MARK | ActionAttr.NO_TAGETS)
 def _toggle_select_visual(view: View, defx: Defx, context: Context) -> None:
     if context.visual_start <= 0 or context.visual_end <= 0:
         return
@@ -214,6 +205,7 @@ def _toggle_select_visual(view: View, defx: Defx, context: Context) -> None:
         candidate['is_selected'] = not candidate['is_selected']
 
 
+@action(name='toggle_sort', attr=ActionAttr.MARK | ActionAttr.NO_TAGETS)
 def _toggle_sort(view: View, defx: Defx, context: Context) -> None:
     """
     Toggle the current sort method.
@@ -226,6 +218,7 @@ def _toggle_sort(view: View, defx: Defx, context: Context) -> None:
         defx._sort_method = sort
 
 
+@action(name='yank_path')
 def _yank_path(view: View, defx: Defx, context: Context) -> None:
     yank = '\n'.join([str(x['action__path']) for x in context.targets])
     view._vim.call('setreg', '"', yank)

--- a/rplugin/python3/defx/kind/file.py
+++ b/rplugin/python3/defx/kind/file.py
@@ -12,7 +12,7 @@ import typing
 
 from defx.action import ActionAttr
 from defx.action import ActionTable
-from defx.base.kind import Base
+from defx.base.kind import Base, action
 from defx.clipboard import ClipboardAction
 from defx.context import Context
 from defx.defx import Defx
@@ -29,28 +29,6 @@ class Kind(Base):
 
     def get_actions(self) -> typing.Dict[str, ActionTable]:
         actions = super().get_actions()
-        actions.update({
-            'cd': ActionTable(func=_cd),
-            'change_vim_cwd': ActionTable(
-                func=_change_vim_cwd, attr=ActionAttr.NO_TAGETS),
-            'check_redraw': ActionTable(
-                func=_check_redraw, attr=ActionAttr.NO_TAGETS),
-            'copy': ActionTable(func=_copy),
-            'drop': ActionTable(func=_drop),
-            'execute_command': ActionTable(
-                func=_execute_command, attr=ActionAttr.NO_TAGETS),
-            'execute_system': ActionTable(func=_execute_system),
-            'move': ActionTable(func=_move),
-            'new_directory': ActionTable(func=_new_directory),
-            'new_file': ActionTable(func=_new_file),
-            'new_multiple_files': ActionTable(func=_new_multiple_files),
-            'open': ActionTable(func=_open),
-            'open_directory': ActionTable(func=_open_directory),
-            'paste': ActionTable(func=_paste, attr=ActionAttr.NO_TAGETS),
-            'remove': ActionTable(func=_remove, attr=ActionAttr.REDRAW),
-            'remove_trash': ActionTable(func=_remove_trash),
-            'rename': ActionTable(func=_rename),
-        })
         return actions
 
 
@@ -82,6 +60,7 @@ def check_overwrite(view: View, dest: Path, src: Path) -> Path:
     return ret
 
 
+@action(name='cd')
 def _cd(view: View, defx: Defx, context: Context) -> None:
     """
     Change the current directory.
@@ -98,6 +77,7 @@ def _cd(view: View, defx: Defx, context: Context) -> None:
         view.search_file(Path(prev_cwd), defx._index)
 
 
+@action(name='change_vim_cwd', attr=ActionAttr.NO_TAGETS)
 def _change_vim_cwd(view: View, defx: Defx, context: Context) -> None:
     """
     Change the current working directory.
@@ -105,6 +85,7 @@ def _change_vim_cwd(view: View, defx: Defx, context: Context) -> None:
     cd(view._vim, defx._cwd)
 
 
+@action(name='check_redraw', attr=ActionAttr.NO_TAGETS)
 def _check_redraw(view: View, defx: Defx, context: Context) -> None:
     root = defx.get_root_candidate()
     mtime = root['action__path'].stat().st_mtime
@@ -112,6 +93,7 @@ def _check_redraw(view: View, defx: Defx, context: Context) -> None:
         view.redraw(True)
 
 
+@action(name='copy')
 def _copy(view: View, defx: Defx, context: Context) -> None:
     if not context.targets:
         return
@@ -126,6 +108,7 @@ def _copy(view: View, defx: Defx, context: Context) -> None:
     view._clipboard.candidates = context.targets
 
 
+@action(name='drop')
 def _drop(view: View, defx: Defx, context: Context) -> None:
     """
     Open like :drop.
@@ -155,6 +138,7 @@ def _drop(view: View, defx: Defx, context: Context) -> None:
             view._vim.call('defx#util#execute_path', command, str(path))
 
 
+@action(name='execute_command', attr=ActionAttr.NO_TAGETS)
 def _execute_command(view: View, defx: Defx, context: Context) -> None:
     """
     Execute the command.
@@ -172,6 +156,7 @@ def _execute_command(view: View, defx: Defx, context: Context) -> None:
     cd(view._vim, save_cwd)
 
 
+@action(name='execute_system')
 def _execute_system(view: View, defx: Defx, context: Context) -> None:
     """
     Execute the file by system associated command.
@@ -180,6 +165,7 @@ def _execute_system(view: View, defx: Defx, context: Context) -> None:
         view._vim.call('defx#util#open', str(target['action__path']))
 
 
+@action(name='move')
 def _move(view: View, defx: Defx, context: Context) -> None:
     if not context.targets:
         return
@@ -194,6 +180,7 @@ def _move(view: View, defx: Defx, context: Context) -> None:
     view._clipboard.candidates = context.targets
 
 
+@action(name='new_directory')
 def _new_directory(view: View, defx: Defx, context: Context) -> None:
     """
     Create a new directory.
@@ -224,6 +211,7 @@ def _new_directory(view: View, defx: Defx, context: Context) -> None:
     view.search_file(filename, defx._index)
 
 
+@action(name='new_file')
 def _new_file(view: View, defx: Defx, context: Context) -> None:
     """
     Create a new file and it's parent directories.
@@ -260,6 +248,7 @@ def _new_file(view: View, defx: Defx, context: Context) -> None:
     view.search_file(filename, defx._index)
 
 
+@action(name='new_multiple_files')
 def _new_multiple_files(view: View, defx: Defx, context: Context) -> None:
     """
     Create multiple files.
@@ -302,6 +291,7 @@ def _new_multiple_files(view: View, defx: Defx, context: Context) -> None:
     view.search_file(filename, defx._index)
 
 
+@action(name='open')
 def _open(view: View, defx: Defx, context: Context) -> None:
     """
     Open the file.
@@ -320,6 +310,7 @@ def _open(view: View, defx: Defx, context: Context) -> None:
         view._vim.call('defx#util#execute_path', command, str(path))
 
 
+@action(name='open_directory')
 def _open_directory(view: View, defx: Defx, context: Context) -> None:
     """
     Open the directory.
@@ -334,6 +325,7 @@ def _open_directory(view: View, defx: Defx, context: Context) -> None:
         view.cd(defx, str(path), context.cursor)
 
 
+@action(name='paste', attr=ActionAttr.NO_TAGETS)
 def _paste(view: View, defx: Defx, context: Context) -> None:
     candidate = view.get_cursor_candidate(context.cursor)
     if not candidate:
@@ -375,6 +367,7 @@ def _paste(view: View, defx: Defx, context: Context) -> None:
         view.search_file(dest, defx._index)
 
 
+@action(name='remove', attr=ActionAttr.REDRAW)
 def _remove(view: View, defx: Defx, context: Context) -> None:
     """
     Delete the file or directory.
@@ -400,6 +393,7 @@ def _remove(view: View, defx: Defx, context: Context) -> None:
             path.unlink()
 
 
+@action(name='remove_trash')
 def _remove_trash(view: View, defx: Defx, context: Context) -> None:
     """
     Delete the file or directory.
@@ -426,6 +420,7 @@ def _remove_trash(view: View, defx: Defx, context: Context) -> None:
     view.redraw(True)
 
 
+@action(name='rename')
 def _rename(view: View, defx: Defx, context: Context) -> None:
     """
     Rename the file or directory.


### PR DESCRIPTION
ref #117 
I think using the decorator to register an action is more flexible than manually registering the action. Just like:
```py
@action(name='cd')
def _cd(view: View, defx: Defx, context: Context) -> None:
```
I'm not sure if there is compatibility with such a change, I just did some manual testing.