### PR TITLE
Abstract indent to column

### DIFF
--- a/autoload/defx/init.vim
+++ b/autoload/defx/init.vim
@@ -95,7 +95,7 @@ function! defx#init#_user_options() abort
         \ 'auto_cd': v:false,
         \ 'auto_recursive_level': 0,
         \ 'buffer_name': 'default',
-        \ 'columns': 'mark:filename:type',
+        \ 'columns': 'mark:indent:icon:filename:type',
         \ 'direction': '',
         \ 'ignored_files': '.*',
         \ 'listed': v:false,

--- a/doc/defx.txt
+++ b/doc/defx.txt
@@ -98,10 +98,13 @@ defx#custom#column({column-name}, {dict})
 		to {value}.  You may specify multiple sources with the
 		separator "," in {column-name}. >
 
-	call defx#custom#column('filename', {
+	call defx#custom#column('icon', {
 	      \ 'directory_icon': '▸',
 	      \ 'opened_icon': '▾',
 	      \ 'root_icon': ' ',
+	      \ })
+
+	call defx#custom#column('filename', {
 	      \ 'min_width': 40,
 	      \ 'max_width': 40,
 	      \ })
@@ -123,7 +126,7 @@ defx#custom#option({buffer-name}, {dict})
 		substituted to "_", and "-" prefix is removed. >
 
 	call defx#custom#option('_', {
-	      \ 'columns': 'mark:filename:type:size:time',
+	      \ 'columns': 'mark:indent:icon:filename:type:size:time',
 	      \ })
 <
 							*defx#custom#source()*
@@ -395,7 +398,7 @@ OPTIONS							*defx-options*
 							*defx-option-columns*
 -columns={columns1:columns2,...}
 		Specify defx columns.
-		Default: "mark:filename:type"
+		Default: "mark:indent:icon:filename:type"
 
 						*defx-option-direction*
 -direction={direction}
@@ -518,21 +521,27 @@ COLUMNS							*defx-columns*
 filename	File name.
 
 		variables:
-		directory_icon	  the closed directory icon
-				  (default: "+")
-		indent		  the tree indentation
-				  (default: " ")
 		min_width	  the minimum width of a defx buffer
 				  (default: 40)
 		max_width	  the maximum width of a defx buffer
 				  (default: 100)
+		root_marker_highlight
+				the root marker highlight
+				  (default: "Constant")
+
+							*defx-column-basic*
+icon		Basic icon.
+
+		variables:
+		directory_icon	  the closed directory icon
+				  (default: "+")
 		opened_icon	  the opened directory icon
 				  (default: "-")
 		root_icon	  the root directory icon
 				  (default: " ")
-		root_marker_highlight
-				the root marker highlight
-				  (default: "Constant")
+
+							*defx-column-indent*
+indent		Tree indentation.
 
 							*defx-column-mark*
 mark		File selected mark.
@@ -617,7 +626,7 @@ EXAMPLES						*defx-examples*
 	  \ defx#do_action('new_multiple_files')
 	  nnoremap <silent><buffer><expr> C
 	  \ defx#do_action('toggle_columns',
-	  \                'mark:filename:type:size:time')
+	  \                'mark:indent:icon:filename:type:size:time')
 	  nnoremap <silent><buffer><expr> S
 	  \ defx#do_action('toggle_sort', 'time')
 	  nnoremap <silent><buffer><expr> d

--- a/rplugin/python3/defx/column/filename.py
+++ b/rplugin/python3/defx/column/filename.py
@@ -18,24 +18,17 @@ class Column(Base):
 
         self.name = 'filename'
         self.vars = {
-            'directory_icon': '+',
-            'indent': ' ',
             'min_width': 40,
             'max_width': 100,
-            'opened_icon': '-',
-            'root_icon': ' ',
             'root_marker_highlight': 'Constant',
         }
 
         self._current_length = 0
         self._syntaxes = [
             'directory',
-            'directory_icon',
             'hidden',
             'marker',
-            'opened_icon',
             'root',
-            'root_icon',
         ]
         self._context: Context = Context()
 
@@ -44,17 +37,7 @@ class Column(Base):
 
     def get(self, context: Context,
             candidate: typing.Dict[str, typing.Any]) -> str:
-        if candidate['is_opened_tree']:
-            icon = self.vars['opened_icon']
-        elif candidate['is_root']:
-            icon = self.vars['root_icon']
-        elif candidate['is_directory']:
-            icon = self.vars['directory_icon']
-        else:
-            icon = ' '
-        return self._truncate(
-            self.vars['indent'] * candidate['level'] +
-            icon + ' ' + candidate['word'])
+        return self._truncate(candidate['word'])
 
     def length(self, context: Context) -> int:
         max_fnamewidth = max([self._strwidth(x['word'])
@@ -69,19 +52,6 @@ class Column(Base):
 
     def highlight_commands(self) -> typing.List[str]:
         commands: typing.List[str] = []
-        for icon, highlight in {
-                'directory': 'Special',
-                'opened': 'Special',
-                'root': 'Identifier',
-        }.items():
-            commands.append(
-                ('syntax match {0}_{1}_icon /[{2}]/ ' +
-                 'contained containedin={0}_directory').format(
-                    self.syntax_name, icon, self.vars[icon + '_icon']))
-            commands.append(
-                'highlight default link {}_{}_icon {}'.format(
-                    self.syntax_name, icon, highlight))
-
         commands.append(
             r'syntax match {0}_{1} /\S.*[\\\/]/ '
             'contained containedin={0}'.format(

--- a/rplugin/python3/defx/column/icon.py
+++ b/rplugin/python3/defx/column/icon.py
@@ -1,0 +1,65 @@
+# ============================================================================
+# FILE: icon.py
+# AUTHOR: GuoPan Zhao <zgpio@qq.com>
+# License: MIT license
+# ============================================================================
+
+from defx.base.column import Base
+from defx.context import Context
+from defx.util import Nvim
+
+import typing
+
+
+class Column(Base):
+
+    def __init__(self, vim: Nvim) -> None:
+        super().__init__(vim)
+
+        self.name = 'icon'
+        self.vars = {
+            'length': 1,
+            'directory_icon': '+',
+            'opened_icon': '-',
+            'root_icon': ' ',
+        }
+        self._syntaxes = [
+            'directory_icon',
+            'opened_icon',
+            'root_icon',
+        ]
+
+    def get(self, context: Context,
+            candidate: typing.Dict[str, typing.Any]) -> str:
+        icon: str = ' '
+        if candidate['is_opened_tree']:
+            icon = self.vars['opened_icon']
+        elif candidate['is_root']:
+            icon = self.vars['root_icon']
+        elif candidate['is_directory']:
+            icon = self.vars['directory_icon']
+
+        return icon
+
+    def length(self, context: Context) -> int:
+        return typing.cast(int, self.vars['length'])
+
+    def syntaxes(self) -> typing.List[str]:
+        return [self.syntax_name + '_' + x for x in self._syntaxes]
+
+    def highlight_commands(self) -> typing.List[str]:
+        commands: typing.List[str] = []
+        for icon, highlight in {
+                'directory': 'Special',
+                'opened': 'Special',
+                'root': 'Identifier',
+        }.items():
+            commands.append(
+                ('syntax match {0}_{1}_icon /[{2}]/ ' +
+                 'contained containedin={0}_directory').format(
+                    self.syntax_name, icon, self.vars[icon + '_icon']))
+            commands.append(
+                'highlight default link {}_{}_icon {}'.format(
+                    self.syntax_name, icon, highlight))
+
+        return commands

--- a/rplugin/python3/defx/column/indent.py
+++ b/rplugin/python3/defx/column/indent.py
@@ -1,0 +1,28 @@
+# ============================================================================
+# FILE: indent.py
+# AUTHOR: GuoPan Zhao <zgpio@qq.com>
+# License: MIT license
+# ============================================================================
+
+from defx.base.column import Base
+from defx.context import Context
+from defx.util import Nvim
+
+import typing
+
+
+class Column(Base):
+
+    def __init__(self, vim: Nvim) -> None:
+        super().__init__(vim)
+        self.name = 'indent'
+        self._current_len: int = 0
+
+    def get(self, context: Context,
+            candidate: typing.Dict[str, typing.Any]) -> str:
+        indent: str = ' ' * candidate['level']
+        self._current_len = len(indent)
+        return indent
+
+    def length(self, context: Context) -> int:
+        return self._current_len


### PR DESCRIPTION
In fact, `tree indent` can also be treated as a `column`.
After abstract `indent` to `column` and separate the basic icon from filename
(basic icon named `icon` column, maybe confused with `icons`), users can customize the location of the indent, e.g. when combine with [defx-icons](https://github.com/kristijanhusak/defx-icons), 
using command `:Defx -columns=mark:indent:icons:filename:type`, 
this looks more reasonable and great.

![image](https://user-images.githubusercontent.com/19503791/55635361-10151f80-57f3-11e9-8330-bffab74e5ba5.png)

After abstract `indent` to `column`, users can adjust the `indent column` position to suit your preferences.
If you prefer to make all icons in one column, like this:
`:Defx -columns=mark:icons:indent:icon:filename:type`
![image](https://user-images.githubusercontent.com/19503791/55664709-6de24f80-5865-11e9-8ba1-7732736bf764.png)

Unfortunately, I can't fix the highlight, using `:Defx -columns=indent:icon:filename:type`
![image](https://user-images.githubusercontent.com/19503791/55635524-8154d280-57f3-11e9-895d-4ae843d9fbfd.png)
