### PR TITLE
use buflisted instead

### DIFF
--- a/rplugin/python3/defx/view.py
+++ b/rplugin/python3/defx/view.py
@@ -350,7 +350,7 @@ class View(object):
         # Create new buffer
         vertical = 'vertical' if self._context.split == 'vertical' else ''
         no_split = self._context.split in ['no', 'tab', 'floating']
-        if self._vim.call('bufexists', self._bufnr):
+        if self._vim.call('buflisted', self._bufnr):
             command = ('buffer' if no_split else 'sbuffer')
             self._vim.command(
                 'silent keepalt %s %s %s %s' % (


### PR DESCRIPTION
# Reproduce the problem
1. nvim -u init.vim
    init.vim
    ```viml
    set rtp+=~/test_nvim/defx.nvim/
    ```
1. `:Defx`
1. `:bd`
1. `:Defx -resume`

If defx buffer is in unlisted state, -resume cannot restore buffer.