### PR TITLE
Fix drop action

### DIFF
--- a/rplugin/python3/defx/kind/file.py
+++ b/rplugin/python3/defx/kind/file.py
@@ -140,7 +140,7 @@ def _drop(view: View, defx: Defx, context: Context) -> None:
             view.cd(defx, str(path), context.cursor)
             continue
 
-        bufnr = view._vim.call('bufnr', str(path))
+        bufnr = view._vim.call('bufnr', f'^{path}$')
         winids = view._vim.call('win_findbuf', bufnr)
 
         if winids:


### PR DESCRIPTION
This pr will fix `drop` action problem.
`bufnr()` requires a file pattern if you want to match exactly.

### Problem
1. open `.env.sample`
2. `Defx -split=vertical`
3. execute drop action `.env`
4. but move to `.env.sample` window

### FYI
- https://vim-jp.org/vimdoc-ja/eval.html#bufname()
