### PR TITLE
Remove whitespaces in filename and dirname

### DIFF
--- a/rplugin/python3/defx/util.py
+++ b/rplugin/python3/defx/util.py
@@ -24,6 +24,7 @@ def cwd_input(vim: Nvim, cwd: str, prompt: str,
     cd(vim, cwd)
 
     filename: str = vim_input(vim, prompt, text, completion)
+    filename = filename.strip()
 
     cd(vim, save_cwd)
 


### PR DESCRIPTION
In this situation:
```
Please input a new filename: test.py |
```
(here `|` is the cursor)

And then defx will creates a file `test.py ` but not `test.py`. So the input must be trimmed firstly