### PR TITLE
fix cursor jump

### DIFF
--- a/rplugin/python3/defx/view.py
+++ b/rplugin/python3/defx/view.py
@@ -142,10 +142,18 @@ class View(object):
             column.on_redraw(self._context)
 
         self._buffer.options['modifiable'] = True
-        self._buffer[:] = [
+        lines = [
             self._get_columns_text(self._context, x)
             for x in self._candidates
         ]
+        # NOTE: Different len of buffer line replacement cause cursor jump
+        if len(lines) >= len(self._buffer):
+            self._buffer[:] = lines[:len(self._buffer)]
+            self._buffer.append(lines[len(self._buffer):])
+        else:
+            self._buffer[len(lines):] = []
+            self._buffer[:] = lines
+
         self._buffer.options['modifiable'] = False
         self._buffer.options['modified'] = False
 


### PR DESCRIPTION
# Problems summary

## Environment Information

 * defx version(SHA1): e4259b3
 * OS: macos
 * neovim/Vim version: NVIM v0.4.0-1856-g82d52b229

## Provide a minimal init.vim/vimrc with less than 50 lines (Required!)

min_vimrc.vim
```vim
set rtp+=~/test_vim/defx.nvim/

nnoremap <silent> <Space>e :<C-u>Defx -split=vertical -direction=topleft -winwidth=40 -listed -resume <CR>

let $NVIM_RPLUGIN_MANIFEST = './defx_rplugin.vim'
autocmd filetype defx call Defx_ft()
func Defx_ft()
  nnoremap <silent><buffer><expr> o defx#async_action('open_or_close_tree')
  nnoremap <silent><buffer><expr> l defx#async_action('open')
endf
```

## The reproduce ways from neovim/Vim starting (Required!)

 1. prepare files
```bash
mkdir fool
mkdir fool/dir_{1..1000}
touch fool/dir_{1..1000}/document.txt
```
 2. nvim -u min_vimrc.vim
 3. `<space>e` open defx and `l` go to `fool` dir
 4. `G` to `dir_1000/`, and use `o` to open
 5. use `o` again for close, you will see cursor jump to line and then jump back to `dir_1000`

## Screen shot (if possible)
see [video](https://asciinema.org/a/iaUoATD94uxvJVnCREPSwX34S)

 