### PR TITLE
update set number status

### DIFF
--- a/autoload/defx/util.vim
+++ b/autoload/defx/util.vim
@@ -68,8 +68,14 @@ function! s:substitute_path_separator(path) abort
 endfunction
 
 function! defx#util#call_defx(command, args) abort
-  let [paths, context] = defx#util#_parse_options_args(a:args)
-  call defx#start(paths, context)
+  if &number
+    let [paths, context] = defx#util#_parse_options_args(a:args)
+    call defx#start(paths, context)
+    set number
+  else
+    let [paths, context] = defx#util#_parse_options_args(a:args)
+    call defx#start(paths, context)
+  endif
 endfunction
 
 function! defx#util#_parse_options_args(cmdline) abort
@@ -262,7 +268,7 @@ function! defx#util#truncate_skipping(str, max, footer_width, separator) abort
   else
     let header_width = a:max - strwidth(a:separator) - a:footer_width
     let ret = s:strwidthpart(a:str, header_width) . a:separator
-         \ . s:strwidthpart_reverse(a:str, a:footer_width)
+          \ . s:strwidthpart_reverse(a:str, a:footer_width)
   endif
   return s:truncate(ret, a:max)
 endfunction


### PR DESCRIPTION
Fixed an issue where `set number` was reset when opening a new file in `Defx` even if `set number` was written in `.vimrc` or `init.vim.`

Please check this code.

# writing set number in .vimrc or init.vim

<img width="215" alt="スクリーンショット 2019-09-05 23 46 32" src="https://user-images.githubusercontent.com/36619465/64352678-6c48cd80-d037-11e9-971f-7a4eeec6e898.png">

# Not writing

<img width="209" alt="スクリーンショット 2019-09-05 23 46 11" src="https://user-images.githubusercontent.com/36619465/64352684-6eab2780-d037-11e9-89dd-a54e40e3af6f.png">

## Gif

### set number writing

![Untitled](https://user-images.githubusercontent.com/36619465/64355231-cfd4fa00-d03b-11e9-9cb0-67c1ec808119.gif)

### not set number writing

![Untitled](https://user-images.githubusercontent.com/36619465/64355369-0e6ab480-d03c-11e9-847b-7b1539f441ab.gif)




