### PR TITLE
Fix :drop behavior where defx window sometimes replaced inplace unnecessarily

### DIFF
--- a/rplugin/python3/defx/kind/file.py
+++ b/rplugin/python3/defx/kind/file.py
@@ -148,10 +148,7 @@ def _drop(view: View, defx: Defx, context: Context) -> None:
         if winids:
             view._vim.call('win_gotoid', winids[0])
         else:
-            if context.prev_winid != view._winid:
-                view._vim.call('win_gotoid', context.prev_winid)
-            else:
-                view._vim.command('wincmd w')
+            view._vim.command('wincmd w')
             if path.match(cwd):
                 path = path.relative_to(cwd)
             view._vim.call('defx#util#execute_path', command, str(path))


### PR DESCRIPTION
## Before

When two vertical windows are created and one is closed, the "drop" action used to overwrite the defx buffer instead of using the window to the right.

![broken-drop](https://user-images.githubusercontent.com/3723671/69491344-eaac5300-0e61-11ea-818f-bfc30f9c1b3f.gif)

## After

Now, the defx buffer is only overwritten by drop if it's the only buffer:

![fixed-drop](https://user-images.githubusercontent.com/3723671/69491354-f4ce5180-0e61-11ea-9459-6133c6c7d115.gif)

## Note

I don't fully understand the purpose of the line I removed. That said, my changes fix the unfortunate behaviour. I wouldn't be surprised if you have a more-elegant / robust fix. Thanks!