### PR TITLE
Use relative path when opening file with open or drop

### DIFF
--- a/rplugin/python3/defx/kind/file.py
+++ b/rplugin/python3/defx/kind/file.py
@@ -325,8 +325,10 @@ def _open(view: View, defx: Defx, context: Context) -> None:
             view.cd(defx, str(path), context.cursor)
             continue
 
-        if path.match(cwd):
+        try:
             path = path.relative_to(cwd)
+        except ValueError:
+            pass
         view._vim.call('defx#util#execute_path', command, str(path))
 
 

--- a/rplugin/python3/defx/kind/file.py
+++ b/rplugin/python3/defx/kind/file.py
@@ -153,8 +153,10 @@ def _drop(view: View, defx: Defx, context: Context) -> None:
                 view._vim.call('win_gotoid', context.prev_winid)
             else:
                 view._vim.command('wincmd w')
-            if path.match(cwd):
+            try:
                 path = path.relative_to(cwd)
+            except ValueError:
+                pass
             view._vim.call('defx#util#execute_path', command, str(path))
 
 


### PR DESCRIPTION
This always tries to set the path of the opened file relative to the current working directory, fixing #202.