### PR TITLE
Clear clipboard after moved

### DIFF
--- a/rplugin/python3/defx/kind/file.py
+++ b/rplugin/python3/defx/kind/file.py
@@ -15,7 +15,7 @@ import typing
 from defx.action import ActionAttr
 from defx.action import ActionTable
 from defx.base.kind import Base
-from defx.clipboard import ClipboardAction
+from defx.clipboard import Clipboard, ClipboardAction
 from defx.context import Context
 from defx.defx import Defx
 from defx.util import cd, cwd_input, confirm, error, Candidate
@@ -399,6 +399,8 @@ def _paste(view: View, defx: Defx, context: Context) -> None:
                     dest.unlink()
             shutil.move(str(path), cwd)
         view._vim.command('redraw')
+    if action == ClipboardAction.MOVE:
+        view._clipboard = Clipboard()
     view._vim.command('echo')
 
     view.redraw(True)


### PR DESCRIPTION
# Problems summary
After pasted, moved files doesn't exist any more, clipboard should be cleared, otherwise future pasting will panic.

## Expected
No panic in future pasting.

## Provide a minimal init.vim/vimrc with less than 50 lines (Required!)

```vim
set nocompatible
set runtimepath+=~/.cache/vim/dein/repos/github.com/Shougo/defx.nvim

augroup defx_init
  autocmd FileType defx call s:defx_init()
augroup END

function! s:defx_init() abort
  nnoremap <silent><buffer><expr> o             defx#do_action('open_tree', ['nested'])
  nnoremap <silent><buffer><expr> m             defx#do_action('move')
  nnoremap <silent><buffer><expr> p             defx#do_action('paste')
  nnoremap <silent><buffer><expr> <Space>       defx#async_action('toggle_select') . 'j'
endfunction

exe 'helptags ALL'
```

## Screen shot (if possible)
![Screen Recording 2020-08-15 at 18 06 22 2020-08-15 18_32_25](https://user-images.githubusercontent.com/541734/90310759-38ed0f00-df27-11ea-85f1-3ab9472f4184.gif)

