### PR TITLE
Restore relative paths for `drop` command

### DIFF
--- a/rplugin/python3/defx/kind/file.py
+++ b/rplugin/python3/defx/kind/file.py
@@ -144,7 +144,7 @@ def _drop(view: View, defx: Defx, context: Context) -> None:
     """
     Open like :drop.
     """
-    cwd = view._vim.call('getcwd')
+    cwd = view._vim.call('getcwd', -1)
     command = context.args[0] if context.args else 'edit'
 
     for target in context.targets:

--- a/rplugin/python3/defx/kind/file.py
+++ b/rplugin/python3/defx/kind/file.py
@@ -15,7 +15,7 @@ import typing
 from defx.action import ActionAttr
 from defx.action import ActionTable
 from defx.base.kind import Base
-from defx.clipboard import Clipboard, ClipboardAction
+from defx.clipboard import ClipboardAction
 from defx.context import Context
 from defx.defx import Defx
 from defx.util import cd, cwd_input, confirm, error, Candidate

--- a/rplugin/python3/defx/kind/file.py
+++ b/rplugin/python3/defx/kind/file.py
@@ -144,6 +144,7 @@ def _drop(view: View, defx: Defx, context: Context) -> None:
     """
     Open like :drop.
     """
+    cwd = view._vim.call('getcwd')
     command = context.args[0] if context.args else 'edit'
 
     for target in context.targets:
@@ -164,6 +165,10 @@ def _drop(view: View, defx: Defx, context: Context) -> None:
                 view._vim.call('win_gotoid', context.prev_winid)
             else:
                 view._vim.command('wincmd w')
+            try:
+                path = path.relative_to(cwd)
+            except ValueError:
+                pass
             view._vim.call('defx#util#execute_path', command, str(path))
 
         view.restore_previous_buffer()


### PR DESCRIPTION
The fix for issue #238 removed support for opening files using relative paths in the `drop` command. While this fixes the issue at hand, it also removes useful functionality (see i.e. #202 and #203 where I fixed the broken behaviour).

Checking parameters for `getcwd()` I noticed it is possible to ignore window local working directories as set by `:lcd`, only reading the tab's directory. Adapting the restored code for applying relative paths, this fixes the issue for @Freed-Wu and still retains the old functionality.

To test, the same scenario can be used as described in #238. Tested on NVIM v0.5.0-dev.