### PR TITLE
Enable sort by multiple keys

### DIFF
--- a/rplugin/python3/defx/sort.py
+++ b/rplugin/python3/defx/sort.py
@@ -13,13 +13,15 @@ from defx.util import readable
 
 @functools.total_ordering
 class _Reversed:
-    def __init__(self, obj):
+    def __init__(self, obj: typing.Any) -> None:
         self._obj = obj
 
-    def __lt__(self, other):
+    def __lt__(self, other: '_Reversed') -> typing.Any:
         return self._obj > other._obj
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> typing.Any:
+        if not isinstance(other, _Reversed):
+            return NotImplemented
         return self._obj == other._obj
 
 
@@ -36,8 +38,8 @@ def sort(
 
 def _make_key_func(
         methods: str
-) -> typing.List[typing.Callable[[typing.Dict[str, typing.Any]], typing.Any]]:
-    key_func = []
+) -> typing.Callable[[typing.Any], typing.List[typing.Any]]:
+    key_func: typing.List[typing.Callable[[typing.Any], typing.Any]] = []
     for method in methods.split(':'):
         key = method.lower()
         if key not in SORT_KEY_METHODS:
@@ -52,7 +54,7 @@ def _make_key_func(
 
 
 def _make_reversed_key(
-        key_method: str
+        key_method: typing.Callable[[typing.Dict[str, typing.Any]], typing.Any]
 ) -> typing.Callable[[typing.Dict[str, typing.Any]], typing.Any]:
     return lambda x: _Reversed(key_method(x))
 

--- a/rplugin/python3/defx/sort.py
+++ b/rplugin/python3/defx/sort.py
@@ -15,8 +15,10 @@ from defx.util import readable
 class _Reversed:
     def __init__(self, obj):
         self._obj = obj
+
     def __lt__(self, other):
         return self._obj > other._obj
+
     def __eq__(self, other):
         return self._obj == other._obj
 
@@ -50,7 +52,7 @@ def _make_key_func(
 
 
 def _make_reversed_key(
-        key_method : str
+        key_method: str
 ) -> typing.Callable[[typing.Dict[str, typing.Any]], typing.Any]:
     return lambda x: _Reversed(key_method(x))
 

--- a/rplugin/python3/defx/sort.py
+++ b/rplugin/python3/defx/sort.py
@@ -4,70 +4,90 @@
 # License: MIT license
 # ============================================================================
 
+import functools
 import re
 import typing
 
 from defx.util import readable
 
 
+@functools.total_ordering
+class _Reversed:
+    def __init__(self, obj):
+        self._obj = obj
+    def __lt__(self, other):
+        return self._obj > other._obj
+    def __eq__(self, other):
+        return self._obj == other._obj
+
+
 def sort(
         method: str, candidates: typing.List[typing.Dict[str, typing.Any]]
 ) -> typing.List[typing.Dict[str, typing.Any]]:
-    dirs = _sort_method(
-        method, [x for x in candidates if x['is_directory']])
-    files = _sort_method(
-        method, [x for x in candidates if not x['is_directory']])
+    key_func = _make_key_func(method)
+    dirs = sorted(
+        [x for x in candidates if x['is_directory']], key=key_func)
+    files = sorted(
+        [x for x in candidates if not x['is_directory']], key=key_func)
     return dirs + files
 
 
-def _sort_method(
-        method: str, candidates: typing.List[typing.Dict[str, typing.Any]]
-) -> typing.List[typing.Dict[str, typing.Any]]:
-    key = method.lower()
-    if key not in SORT_METHODS:
-        return candidates
+def _make_key_func(
+        methods: str
+) -> typing.List[typing.Callable[[typing.Dict[str, typing.Any]], typing.Any]]:
+    key_func = []
+    for method in methods.split(':'):
+        key = method.lower()
+        if key not in SORT_KEY_METHODS:
+            continue
 
-    candidates = SORT_METHODS[key](candidates)
-    if re.match(r'[A-Z]', method):
-        candidates = list(reversed(candidates))
-    return candidates
+        key_method = SORT_KEY_METHODS[key]
+        if re.match(r'[A-Z]', method):
+            key_func.append(_make_reversed_key(key_method))
+        else:
+            key_func.append(key_method)
+    return lambda x: [f(x) for f in key_func]
+
+
+def _make_reversed_key(
+        key_method : str
+) -> typing.Callable[[typing.Dict[str, typing.Any]], typing.Any]:
+    return lambda x: _Reversed(key_method(x))
 
 
 def _extension(
-        candidates: typing.List[typing.Dict[str, typing.Any]]
-) -> typing.List[typing.Dict[str, typing.Any]]:
-    return sorted(candidates, key=lambda x: str(x['action__path'].suffix))
+        candidate: typing.Dict[str, typing.Any]
+) -> typing.Any:
+    return str(candidate['action__path'].suffix)
 
 
 def _filename(
-        candidates: typing.List[typing.Dict[str, typing.Any]]
-) -> typing.List[typing.Dict[str, typing.Any]]:
+        candidate: typing.Dict[str, typing.Any]
+) -> typing.Any:
 
     def numeric_key(v: str) -> typing.List[typing.Any]:
         keys = re.split(r'(\d+)', v)
         keys[1::2] = [int(x) for x in keys[1::2]]  # type: ignore
         return keys
 
-    return sorted(candidates, key=lambda x: numeric_key(x['word'].lower()))
+    return numeric_key(candidate['word'].lower())
 
 
 def _size(
-        candidates: typing.List[typing.Dict[str, typing.Any]]
-) -> typing.List[typing.Dict[str, typing.Any]]:
-    return sorted(candidates, key=(lambda x:
-                                   int(x['action__path'].stat().st_size)
-                                   if readable(x['action__path']) else -1))
+        candidate: typing.Dict[str, typing.Any]
+) -> typing.Any:
+    return (int(candidate['action__path'].stat().st_size)
+            if readable(candidate['action__path']) else -1)
 
 
 def _time(
-        candidates: typing.List[typing.Dict[str, typing.Any]]
-) -> typing.List[typing.Dict[str, typing.Any]]:
-    return sorted(candidates, key=(lambda x:
-                                   int(x['action__path'].stat().st_mtime)
-                                   if readable(x['action__path']) else 0))
+        candidate: typing.Dict[str, typing.Any]
+) -> typing.Any:
+    return (int(candidate['action__path'].stat().st_mtime)
+            if readable(candidate['action__path']) else 0)
 
 
-SORT_METHODS = {
+SORT_KEY_METHODS = {
     'extension': _extension,
     'filename': _filename,
     'size': _size,


### PR DESCRIPTION
I want to sort files by filename among same extension files.
This PR enable to specify second or more sort key (e.g. `-sort=extension:filename`)
