### PR TITLE
Treat negative max_width column as absolute value, not as percentage

### DIFF
--- a/doc/defx.txt
+++ b/doc/defx.txt
@@ -684,10 +684,14 @@ filename	File name.
 		min_width	  the minimum width of a defx buffer
 				  (default: 40)
 		max_width	  the maximum width of a defx buffer
+				  Negative value sets width exactly to:
+				  "winwidth - (-max_width)".
+				  Example: "-36" max_width means width
+				  is "winwidth - 36".
 				  (default: 100)
 		max_width_percent
-				  the maximum width of a defx buffer
-				  It means: "winwidth -max_width / 100".
+				  the maximum width in percentage of a defx buffer
+				  It means: "winwidth * max_width_percent / 100".
 				  Example: "120" max_width_percent means 120
 				  percent winwidth.
 				  (default: 0)
@@ -928,6 +932,7 @@ COMPATIBILITY						*defx-compatibility*
 
 2020-12-17
 * "max_width_percent" is added instead of negative value of "max_width".
+* "max_width" negative value sets max_width to current window width plus "max_width".
 
 2020-05-04
 * "open_tree_recursive" and "open_or_close_tree" actions are deprecated.

--- a/rplugin/python3/defx/column/filename.py
+++ b/rplugin/python3/defx/column/filename.py
@@ -70,12 +70,16 @@ class Column(Base):
         max_fnamewidth += context.variable_length
         max_fnamewidth += len(self._file_marker)
         max_width = int(self.vars['max_width'])
-        max_width_percent = int(self.vars['max_width_percent'])
-        if max_width_percent > 0:
-            max_width = int(max_width_percent * context.winwidth / 100)
+        if max_width < 0:
+            self._current_length = int(context.winwidth + max_width)
+        else:
+            max_width_percent = int(self.vars['max_width_percent'])
+            if max_width_percent > 0:
+                max_width = int(max_width_percent * context.winwidth / 100)
+            self._current_length = min(max_fnamewidth, max_width)
         self._current_length = max(
-            min(max_fnamewidth, max_width),
-            int(self.vars['min_width']))
+                self._current_length,
+                int(self.vars['min_width']))
         return self._current_length
 
     def syntaxes(self) -> typing.List[str]:


### PR DESCRIPTION
Hello Shougo,

Please consider this. It allows column to have dynamic width depending on width of
other columns and total buffer width. This makes column to always fit fully available space.
It allows right alignment of columns right to column using this negative max_width.
Looks much nicer than current percentage where the column width is always a bit off because it is percentage. 