### PR TITLE
Enable new_multiple_files action support escaped space and quotes.

### DIFF
--- a/rplugin/python3/defx/kind/file.py
+++ b/rplugin/python3/defx/kind/file.py
@@ -378,7 +378,7 @@ def _new_multiple_files(view: View, defx: Defx, context: Context) -> None:
     if not str_filenames:
         return None
 
-    for name in str_filenames.split():
+    for name in shlex.split(str_filenames):
         is_dir = name[-1] == '/'
 
         filename = Path(cwd).joinpath(name)


### PR DESCRIPTION
Enable action `new_multiple_files` create one directory `1 3` and two files: `123`, `12 3` with parameters:`1\ 3/ 123 '12 3'`.