### PR TITLE
Allow external sources to copy files to local

### DIFF
--- a/rplugin/python3/defx/clipboard.py
+++ b/rplugin/python3/defx/clipboard.py
@@ -14,10 +14,19 @@ class ClipboardAction(Enum):
     LINK = auto()
 
 
+def default_paster(src: str, dest: str) -> None:
+    pass
+
+
 class Clipboard():
     def __init__(self,
                  action: ClipboardAction = ClipboardAction.COPY,
                  candidates:
-                 typing.List[typing.Dict[str, typing.Any]] = []) -> None:
+                 typing.List[typing.Dict[str, typing.Any]] = [],
+                 source_name: str = 'file',
+                 paster: typing.Callable[[str, str], None] = default_paster
+                 ) -> None:
         self.action = action
         self.candidates = candidates
+        self.source_name = source_name
+        self.paster = paster

--- a/rplugin/python3/defx/kind/file.py
+++ b/rplugin/python3/defx/kind/file.py
@@ -181,6 +181,7 @@ def _copy(view: View, defx: Defx, context: Context) -> None:
 
     view._clipboard.action = ClipboardAction.COPY
     view._clipboard.candidates = context.targets
+    view._clipboard.source_name = 'file'
 
 
 @action(name='drop')
@@ -294,6 +295,7 @@ def _link(view: View, defx: Defx, context: Context) -> None:
 
     view._clipboard.action = ClipboardAction.LINK
     view._clipboard.candidates = context.targets
+    view._clipboard.source_name = 'file'
 
 
 @action(name='move')
@@ -309,6 +311,7 @@ def _move(view: View, defx: Defx, context: Context) -> None:
 
     view._clipboard.action = ClipboardAction.MOVE
     view._clipboard.candidates = context.targets
+    view._clipboard.source_name = 'file'
 
 
 @action(name='new_directory')
@@ -512,6 +515,11 @@ def _paste(view: View, defx: Defx, context: Context) -> None:
                 shutil.rmtree(str(dest))
             else:
                 dest.unlink()
+
+        if view._clipboard.source_name != 'file':
+            view._clipboard.paster(str(path), str(dest))
+            view._vim.command('redraw')
+            continue
 
         if action == ClipboardAction.COPY:
             if path.is_dir():


### PR DESCRIPTION
This PR allows external sources to send files to local path.
Sending files will become possible by defining `Clipboard.paster`, which tells how to send external files to local.
This is an example using this feature: copy action of my [sftp source](https://github.com/matsui54/defx-sftp).
``` python
# defx-sftp/rplugin/python3/defx/kind/sftp.py
@action(name='copy')
def _copy(view: View, defx: Defx, context: Context) -> None:
    if not context.targets:
        return

    message = 'Copy to the clipboard: {}'.format(
        str(context.targets[0]['action__path'])
        if len(context.targets) == 1
        else str(len(context.targets)) + ' files')
    view.print_msg(message)

    def copy_to_local(path: str, dest: str):
        client = defx._source.client
      # send remote file to local
        client.get(path, dest)

    view._clipboard.action = ClipboardAction.COPY
    view._clipboard.candidates = context.targets
    view._clipboard.source_name = 'sftp'
    view._clipboard.paster = copy_to_local
```
