### PR TITLE
[RDY] Make creating sources easier

### DIFF
--- a/rplugin/python3/defx/base/kind.py
+++ b/rplugin/python3/defx/base/kind.py
@@ -28,8 +28,9 @@ def action(name: str, attr: ActionAttr = ActionAttr.NONE
     def wrapper(func: ACTION_FUNC) -> ACTION_FUNC:
         _action_table[name] = ActionTable(func=func, attr=attr)
 
-        def inner_wrapper(view: View, defx: Defx, context: Context) -> None:
-            return func(view, defx, context)
+        def inner_wrapper(kind: 'Base', view: View, defx: Defx,
+                          context: Context) -> None:
+            return func(kind, view, defx, context)
         return inner_wrapper
     return wrapper
 
@@ -43,301 +44,290 @@ class Base:
     def get_actions(self) -> typing.Dict[str, ActionTable]:
         return _action_table
 
+    @action(name='add_session', attr=ActionAttr.NO_TAGETS)
+    def _add_session(self, view: View, defx: Defx, context: Context) -> None:
+        path = context.args[0] if context.args else defx._cwd
+        if path[-1] == '/':
+            # Remove the last slash
+            path = path[: -1]
 
-@action(name='add_session', attr=ActionAttr.NO_TAGETS)
-def _add_session(view: View, defx: Defx, context: Context) -> None:
-    path = context.args[0] if context.args else defx._cwd
-    if path[-1] == '/':
-        # Remove the last slash
-        path = path[: -1]
+        opened_candidates = [] if context.args else list(
+            defx._opened_candidates)
+        opened_candidates.sort()
 
-    opened_candidates = [] if context.args else list(defx._opened_candidates)
-    opened_candidates.sort()
-
-    session: Session
-    if path in view._sessions:
-        old_session = view._sessions[path]
-        session = Session(
-            name=old_session.name, path=old_session.path,
-            opened_candidates=opened_candidates)
-    else:
-        name = Path(path).name
-        session = Session(
-            name=name, path=path,
-            opened_candidates=opened_candidates)
-        view.print_msg(f'session "{name}" is created')
-
-    view._sessions[session.path] = session
-
-    _save_session(view, defx, context)
-
-
-@action(name='call', attr=ActionAttr.REDRAW)
-def _call(view: View, defx: Defx, context: Context) -> None:
-    """
-    Call the function.
-    """
-    function = context.args[0] if context.args else None
-    if not function:
-        return
-
-    dict_context = context._asdict()
-    dict_context['cwd'] = defx._cwd
-    dict_context['targets'] = [
-        str(x['action__path']) for x in context.targets]
-    view._vim.call(function, dict_context)
-
-
-@action(name='change_filtered_files', attr=ActionAttr.REDRAW)
-def _change_filtered_files(view: View, defx: Defx, context: Context) -> None:
-    filtered_files = context.args[0] if context.args else view._vim.call(
-        'defx#util#input',
-        f'{".".join(defx._filtered_files)} -> ',
-        '.'.join(defx._filtered_files))
-    defx._filtered_files = filtered_files.split(',')
-
-
-@action(name='change_ignored_files', attr=ActionAttr.REDRAW)
-def _change_ignored_files(view: View, defx: Defx, context: Context) -> None:
-    ignored_files = context.args[0] if context.args else view._vim.call(
-        'defx#util#input',
-        f'{".".join(defx._ignored_files)} -> ',
-        '.'.join(defx._ignored_files))
-    defx._ignored_files = ignored_files.split(',')
-
-
-@action(name='clear_select_all', attr=ActionAttr.MARK | ActionAttr.NO_TAGETS)
-def _clear_select_all(view: View, defx: Defx, context: Context) -> None:
-    for candidate in [x for x in view._candidates
-                      if x['_defx_index'] == defx._index]:
-        candidate['is_selected'] = False
-
-
-@action(name='close_tree', attr=ActionAttr.TREE | ActionAttr.CURSOR_TARGET)
-def _close_tree(view: View, defx: Defx, context: Context) -> None:
-    for target in context.targets:
-        if target['is_directory'] and target['is_opened_tree']:
-            view.close_tree(target['action__path'], defx._index)
+        session: Session
+        if path in view._sessions:
+            old_session = view._sessions[path]
+            session = Session(
+                name=old_session.name, path=old_session.path,
+                opened_candidates=opened_candidates)
         else:
-            view.close_tree(target['action__path'].parent, defx._index)
-            view.search_file(target['action__path'].parent, defx._index)
+            name = Path(path).name
+            session = Session(
+                name=name, path=path,
+                opened_candidates=opened_candidates)
+            view.print_msg(f'session "{name}" is created')
 
+        view._sessions[session.path] = session
 
-@action(name='delete_session', attr=ActionAttr.NO_TAGETS)
-def _delete_session(view: View, defx: Defx, context: Context) -> None:
-    if not context.args:
-        return
+        self._save_session(view, defx, context)
 
-    session_name = context.args[0]
-    if session_name not in view._sessions:
-        return
-    view._sessions.pop(session_name)
+    @action(name='call', attr=ActionAttr.REDRAW)
+    def _call(self, view: View, defx: Defx, context: Context) -> None:
+        """
+        Call the function.
+        """
+        function = context.args[0] if context.args else None
+        if not function:
+            return
 
-    _save_session(view, defx, context)
+        dict_context = context._asdict()
+        dict_context['cwd'] = defx._cwd
+        dict_context['targets'] = [
+            str(x['action__path']) for x in context.targets]
+        view._vim.call(function, dict_context)
 
+    @action(name='change_filtered_files', attr=ActionAttr.REDRAW)
+    def _change_filtered_files(self, view: View, defx: Defx,
+                               context: Context) -> None:
+        filtered_files = context.args[0] if context.args else view._vim.call(
+            'defx#util#input',
+            f'{".".join(defx._filtered_files)} -> ',
+            '.'.join(defx._filtered_files))
+        defx._filtered_files = filtered_files.split(',')
 
-@action(name='load_session', attr=ActionAttr.NO_TAGETS)
-def _load_session(view: View, defx: Defx, context: Context) -> None:
-    session_file = Path(context.session_file)
-    if not context.session_file or not session_file.exists():
-        return
+    @action(name='change_ignored_files', attr=ActionAttr.REDRAW)
+    def _change_ignored_files(self, view: View, defx: Defx,
+                              context: Context) -> None:
+        ignored_files = context.args[0] if context.args else view._vim.call(
+            'defx#util#input',
+            f'{".".join(defx._ignored_files)} -> ',
+            '.'.join(defx._ignored_files))
+        defx._ignored_files = ignored_files.split(',')
 
-    loaded_session = json.loads(session_file.read_text())
-    if 'sessions' not in loaded_session:
-        return
+    @action(name='clear_select_all',
+            attr=ActionAttr.MARK | ActionAttr.NO_TAGETS)
+    def _clear_select_all(self, view: View, defx: Defx,
+                          context: Context) -> None:
+        for candidate in [x for x in view._candidates
+                          if x['_defx_index'] == defx._index]:
+            candidate['is_selected'] = False
 
-    view._sessions = {}
-    for path, session in loaded_session['sessions'].items():
-        view._sessions[path] = Session(**session)
+    @action(name='close_tree', attr=ActionAttr.TREE | ActionAttr.CURSOR_TARGET)
+    def _close_tree(self, view: View, defx: Defx, context: Context) -> None:
+        for target in context.targets:
+            if target['is_directory'] and target['is_opened_tree']:
+                view.close_tree(target['action__path'], defx._index)
+            else:
+                view.close_tree(target['action__path'].parent, defx._index)
+                view.search_file(target['action__path'].parent, defx._index)
 
-    view._vim.current.buffer.vars['defx#_sessions'] = [
-        x._asdict() for x in view._sessions.values()
-    ]
+    @action(name='delete_session', attr=ActionAttr.NO_TAGETS)
+    def _delete_session(self, view: View, defx: Defx,
+                        context: Context) -> None:
+        if not context.args:
+            return
 
+        session_name = context.args[0]
+        if session_name not in view._sessions:
+            return
+        view._sessions.pop(session_name)
 
-@action(name='multi')
-def _multi(view: View, defx: Defx, context: Context) -> None:
-    for arg in context.args:
-        args: typing.List[str]
-        if isinstance(arg, list):
-            args = arg
-        else:
-            args = [arg]
-        do_action(view, defx, args[0], context._replace(args=args[1:]))
+        self._save_session(view, defx, context)
 
+    @action(name='load_session', attr=ActionAttr.NO_TAGETS)
+    def _load_session(self, view: View, defx: Defx, context: Context) -> None:
+        session_file = Path(context.session_file)
+        if not context.session_file or not session_file.exists():
+            return
 
-@action(name='check_redraw', attr=ActionAttr.NO_TAGETS)
-def _nop(view: View, defx: Defx, context: Context) -> None:
-    pass
+        loaded_session = json.loads(session_file.read_text())
+        if 'sessions' not in loaded_session:
+            return
 
+        view._sessions = {}
+        for path, session in loaded_session['sessions'].items():
+            view._sessions[path] = Session(**session)
 
-@action(name='open_tree', attr=ActionAttr.TREE | ActionAttr.CURSOR_TARGET)
-def _open_tree(view: View, defx: Defx, context: Context) -> None:
-    nested = False
-    recursive_level = 0
-    toggle = False
-    for arg in context.args:
-        if arg == 'nested':
-            nested = True
-        elif arg == 'recursive':
-            recursive_level = 20
-        elif re.search(r'recursive:\d+', arg):
-            recursive_level = int(arg.split(':')[1])
-        elif arg == 'toggle':
-            toggle = True
+        view._vim.current.buffer.vars['defx#_sessions'] = [
+            x._asdict() for x in view._sessions.values()
+        ]
 
-    for target in [x for x in context.targets if x['is_directory']]:
-        if toggle and not target['is_directory'] or target['is_opened_tree']:
-            _close_tree(view, defx, context._replace(targets=[target]))
-        else:
-            view.open_tree(target['action__path'],
-                           defx._index, nested, recursive_level)
+    @action(name='multi')
+    def _multi(self, view: View, defx: Defx, context: Context) -> None:
+        for arg in context.args:
+            args: typing.List[str]
+            if isinstance(arg, list):
+                args = arg
+            else:
+                args = [arg]
+            do_action(view, defx, args[0], context._replace(args=args[1:]))
 
+    @action(name='check_redraw', attr=ActionAttr.NO_TAGETS)
+    def _nop(self, view: View, defx: Defx, context: Context) -> None:
+        pass
 
-@action(name='open_tree_recursive',
-        attr=ActionAttr.TREE | ActionAttr.CURSOR_TARGET)
-def _open_tree_recursive(view: View, defx: Defx, context: Context) -> None:
-    level = context.args[0] if context.args else '20'
-    _open_tree(view, defx, context._replace(
-        args=context.args + ['recursive:' + level]))
+    @action(name='open_tree', attr=ActionAttr.TREE | ActionAttr.CURSOR_TARGET)
+    def _open_tree(self, view: View, defx: Defx, context: Context) -> None:
+        nested = False
+        recursive_level = 0
+        toggle = False
+        for arg in context.args:
+            if arg == 'nested':
+                nested = True
+            elif arg == 'recursive':
+                recursive_level = 20
+            elif re.search(r'recursive:\d+', arg):
+                recursive_level = int(arg.split(':')[1])
+            elif arg == 'toggle':
+                toggle = True
 
+        for target in [x for x in context.targets if x['is_directory']]:
+            if (toggle and not target['is_directory']
+                    or target['is_opened_tree']):
+                self._close_tree(
+                    view, defx, context._replace(targets=[target]))
+            else:
+                view.open_tree(target['action__path'],
+                               defx._index, nested, recursive_level)
 
-@action(name='open_or_close_tree',
-        attr=ActionAttr.TREE | ActionAttr.CURSOR_TARGET)
-def _open_or_close_tree(view: View, defx: Defx, context: Context) -> None:
-    _open_tree(view, defx, context._replace(args=context.args + ['toggle']))
+    @action(name='open_tree_recursive',
+            attr=ActionAttr.TREE | ActionAttr.CURSOR_TARGET)
+    def _open_tree_recursive(self, view: View, defx: Defx,
+                             context: Context) -> None:
+        level = context.args[0] if context.args else '20'
+        self._open_tree(view, defx, context._replace(
+            args=context.args + ['recursive:' + level]))
 
+    @action(name='open_or_close_tree',
+            attr=ActionAttr.TREE | ActionAttr.CURSOR_TARGET)
+    def _open_or_close_tree(self, view: View, defx: Defx,
+                            context: Context) -> None:
+        self._open_tree(view, defx, context._replace(
+            args=context.args + ['toggle']))
 
-@action(name='print')
-def _print(view: View, defx: Defx, context: Context) -> None:
-    for target in context.targets:
-        view.print_msg(str(target['action__path']))
+    @action(name='print')
+    def _print(self, view: View, defx: Defx, context: Context) -> None:
+        for target in context.targets:
+            view.print_msg(str(target['action__path']))
 
+    @action(name='quit', attr=ActionAttr.NO_TAGETS)
+    def _quit(self, view: View, defx: Defx, context: Context) -> None:
+        view.quit()
 
-@action(name='quit', attr=ActionAttr.NO_TAGETS)
-def _quit(view: View, defx: Defx, context: Context) -> None:
-    view.quit()
+    @action(name='redraw', attr=ActionAttr.NO_TAGETS)
+    def _redraw(self, view: View, defx: Defx, context: Context) -> None:
+        view.redraw(True)
 
+    @action(name='repeat', attr=ActionAttr.MARK)
+    def _repeat(self, view: View, defx: Defx, context: Context) -> None:
+        do_action(view, defx, view._prev_action, context)
 
-@action(name='redraw', attr=ActionAttr.NO_TAGETS)
-def _redraw(view: View, defx: Defx, context: Context) -> None:
-    view.redraw(True)
+    @action(name='resize', attr=ActionAttr.NO_TAGETS)
+    def _resize(self, view: View, defx: Defx, context: Context) -> None:
+        if not context.args:
+            return
 
+        view._context = view._context._replace(winwidth=int(context.args[0]))
+        view._init_window()
+        view.redraw(True)
 
-@action(name='repeat', attr=ActionAttr.MARK)
-def _repeat(view: View, defx: Defx, context: Context) -> None:
-    do_action(view, defx, view._prev_action, context)
+    @action(name='save_session', attr=ActionAttr.NO_TAGETS)
+    def _save_session(self, view: View, defx: Defx, context: Context) -> None:
+        view._vim.current.buffer.vars['defx#_sessions'] = [
+            x._asdict() for x in view._sessions.values()
+        ]
 
+        if not context.session_file:
+            return
 
-@action(name='resize', attr=ActionAttr.NO_TAGETS)
-def _resize(view: View, defx: Defx, context: Context) -> None:
-    if not context.args:
-        return
+        session_file = Path(context.session_file)
+        session_file.write_text(json.dumps({
+            'version': view._session_version,
+            'sessions': {x: y._asdict() for x, y in view._sessions.items()}
+        }))
 
-    view._context = view._context._replace(winwidth=int(context.args[0]))
-    view._init_window()
-    view.redraw(True)
+    @action(name='search', attr=ActionAttr.NO_TAGETS)
+    def _search(self, view: View, defx: Defx, context: Context) -> None:
+        if not context.args or not context.args[0]:
+            return
 
+        search_path = context.args[0]
+        view.search_recursive(Path(search_path), defx._index)
 
-@action(name='save_session', attr=ActionAttr.NO_TAGETS)
-def _save_session(view: View, defx: Defx, context: Context) -> None:
-    view._vim.current.buffer.vars['defx#_sessions'] = [
-        x._asdict() for x in view._sessions.values()
-    ]
+    @action(name='toggle_columns', attr=ActionAttr.REDRAW)
+    def _toggle_columns(self, view: View, defx: Defx,
+                        context: Context) -> None:
+        """
+        Toggle the current columns.
+        """
+        columns = (context.args[0] if context.args else '').split(':')
+        if not columns:
+            return
+        current_columns = [x.name for x in view._columns]
+        if columns == current_columns:
+            # Use default columns
+            columns = context.columns.split(':')
+        view._init_columns(columns)
 
-    if not context.session_file:
-        return
+    @action(name='toggle_ignored_files', attr=ActionAttr.REDRAW)
+    def _toggle_ignored_files(self, view: View, defx: Defx,
+                              context: Context) -> None:
+        defx._enabled_ignored_files = not defx._enabled_ignored_files
 
-    session_file = Path(context.session_file)
-    session_file.write_text(json.dumps({
-        'version': view._session_version,
-        'sessions': {x: y._asdict() for x, y in view._sessions.items()}
-    }))
+    @action(name='toggle_select', attr=ActionAttr.MARK | ActionAttr.NO_TAGETS)
+    def _toggle_select(self, view: View, defx: Defx, context: Context) -> None:
+        candidate = view.get_cursor_candidate(context.cursor)
+        if not candidate:
+            return
 
-
-@action(name='search', attr=ActionAttr.NO_TAGETS)
-def _search(view: View, defx: Defx, context: Context) -> None:
-    if not context.args or not context.args[0]:
-        return
-
-    search_path = context.args[0]
-    view.search_recursive(Path(search_path), defx._index)
-
-
-@action(name='toggle_columns', attr=ActionAttr.REDRAW)
-def _toggle_columns(view: View, defx: Defx, context: Context) -> None:
-    """
-    Toggle the current columns.
-    """
-    columns = (context.args[0] if context.args else '').split(':')
-    if not columns:
-        return
-    current_columns = [x.name for x in view._columns]
-    if columns == current_columns:
-        # Use default columns
-        columns = context.columns.split(':')
-    view._init_columns(columns)
-
-
-@action(name='toggle_ignored_files', attr=ActionAttr.REDRAW)
-def _toggle_ignored_files(view: View, defx: Defx, context: Context) -> None:
-    defx._enabled_ignored_files = not defx._enabled_ignored_files
-
-
-@action(name='toggle_select', attr=ActionAttr.MARK | ActionAttr.NO_TAGETS)
-def _toggle_select(view: View, defx: Defx, context: Context) -> None:
-    candidate = view.get_cursor_candidate(context.cursor)
-    if not candidate:
-        return
-
-    candidate['is_selected'] = not candidate['is_selected']
-
-
-@action(name='toggle_select_all', attr=ActionAttr.MARK | ActionAttr.NO_TAGETS)
-def _toggle_select_all(view: View, defx: Defx, context: Context) -> None:
-    for candidate in [x for x in view._candidates
-                      if not x['is_root'] and
-                      x['_defx_index'] == defx._index]:
         candidate['is_selected'] = not candidate['is_selected']
 
+    @action(name='toggle_select_all',
+            attr=ActionAttr.MARK | ActionAttr.NO_TAGETS)
+    def _toggle_select_all(self, view: View, defx: Defx,
+                           context: Context) -> None:
+        for candidate in [x for x in view._candidates
+                          if not x['is_root'] and
+                          x['_defx_index'] == defx._index]:
+            candidate['is_selected'] = not candidate['is_selected']
 
-@action(name='toggle_select_visual',
-        attr=ActionAttr.MARK | ActionAttr.NO_TAGETS)
-def _toggle_select_visual(view: View, defx: Defx, context: Context) -> None:
-    if context.visual_start <= 0 or context.visual_end <= 0:
-        return
+    @action(name='toggle_select_visual',
+            attr=ActionAttr.MARK | ActionAttr.NO_TAGETS)
+    def _toggle_select_visual(self, view: View, defx: Defx,
+                              context: Context) -> None:
+        if context.visual_start <= 0 or context.visual_end <= 0:
+            return
 
-    start = context.visual_start - 1
-    end = min([context.visual_end, len(view._candidates)])
-    for candidate in [x for x in view._candidates[start:end]
-                      if not x['is_root'] and
-                      x['_defx_index'] == defx._index]:
-        candidate['is_selected'] = not candidate['is_selected']
+        start = context.visual_start - 1
+        end = min([context.visual_end, len(view._candidates)])
+        for candidate in [x for x in view._candidates[start:end]
+                          if not x['is_root'] and
+                          x['_defx_index'] == defx._index]:
+            candidate['is_selected'] = not candidate['is_selected']
 
+    @action(name='toggle_sort', attr=ActionAttr.MARK |
+            ActionAttr.NO_TAGETS | ActionAttr.REDRAW)
+    def _toggle_sort(self, view: View, defx: Defx, context: Context) -> None:
+        """
+        Toggle the current sort method.
+        """
+        sort = context.args[0] if context.args else ''
+        if sort == defx._sort_method:
+            # Use default sort method
+            defx._sort_method = context.sort
+        else:
+            defx._sort_method = sort
 
-@action(name='toggle_sort', attr=ActionAttr.MARK |
-        ActionAttr.NO_TAGETS | ActionAttr.REDRAW)
-def _toggle_sort(view: View, defx: Defx, context: Context) -> None:
-    """
-    Toggle the current sort method.
-    """
-    sort = context.args[0] if context.args else ''
-    if sort == defx._sort_method:
-        # Use default sort method
-        defx._sort_method = context.sort
-    else:
-        defx._sort_method = sort
-
-
-@action(name='yank_path')
-def _yank_path(view: View, defx: Defx, context: Context) -> None:
-    mods = context.args[0] if context.args else ''
-    paths = [str(x['action__path']) for x in context.targets]
-    if mods:
-        paths = [view._vim.call('fnamemodify', x, mods) for x in paths]
-    yank = '\n'.join(paths)
-    view._vim.call('setreg', '"', yank)
-    if (view._vim.call('has', 'clipboard') or
-            view._vim.call('has', 'xterm_clipboard')):
-        view._vim.call('setreg', '+', yank)
-    view.print_msg('Yanked:\n' + yank)
+    @action(name='yank_path')
+    def _yank_path(self, view: View, defx: Defx, context: Context) -> None:
+        mods = context.args[0] if context.args else ''
+        paths = [str(x['action__path']) for x in context.targets]
+        if mods:
+            paths = [view._vim.call('fnamemodify', x, mods) for x in paths]
+        yank = '\n'.join(paths)
+        view._vim.call('setreg', '"', yank)
+        if (view._vim.call('has', 'clipboard') or
+                view._vim.call('has', 'xterm_clipboard')):
+            view._vim.call('setreg', '+', yank)
+        view.print_msg('Yanked:\n' + yank)

--- a/rplugin/python3/defx/kind/file.py
+++ b/rplugin/python3/defx/kind/file.py
@@ -14,7 +14,7 @@ import typing
 
 from defx.action import ActionAttr
 from defx.base.kind import action
-from defx.kind.filelike import Kind
+from defx.kind.filelike import Kind as Base
 from defx.clipboard import ClipboardAction
 from defx.context import Context
 from defx.defx import Defx
@@ -22,10 +22,8 @@ from defx.util import cd, confirm, error, Candidate
 from defx.util import readable
 from defx.view import View
 
-ACTION_FUNC = typing.Callable[[View, Defx, Context], None]
 
-
-class Kind(Kind):
+class Kind(Base):
 
     def __init__(self, vim: Nvim) -> None:
         self.vim = vim

--- a/rplugin/python3/defx/kind/file.py
+++ b/rplugin/python3/defx/kind/file.py
@@ -6,709 +6,164 @@
 
 from pathlib import Path
 from pynvim import Nvim
-import copy
 import importlib
 import mimetypes
-import shlex
 import shutil
 import subprocess
-import re
-import time
 import typing
 
 from defx.action import ActionAttr
-from defx.action import ActionTable
-from defx.base.kind import Base
+from defx.base.kind import action
+from defx.kind.filelike import Kind
 from defx.clipboard import ClipboardAction
 from defx.context import Context
 from defx.defx import Defx
-from defx.util import cd, cwd_input, confirm, error, Candidate
-from defx.util import readable, fnamemodify
+from defx.util import cd, confirm, error, Candidate
+from defx.util import readable
 from defx.view import View
-
-_action_table: typing.Dict[str, ActionTable] = {}
 
 ACTION_FUNC = typing.Callable[[View, Defx, Context], None]
 
 
-def action(name: str, attr: ActionAttr = ActionAttr.NONE
-           ) -> typing.Callable[[ACTION_FUNC], ACTION_FUNC]:
-    def wrapper(func: ACTION_FUNC) -> ACTION_FUNC:
-        _action_table[name] = ActionTable(func=func, attr=attr)
-
-        def inner_wrapper(view: View, defx: Defx, context: Context) -> None:
-            return func(view, defx, context)
-        return inner_wrapper
-    return wrapper
-
-
-class Kind(Base):
+class Kind(Kind):
 
     def __init__(self, vim: Nvim) -> None:
         self.vim = vim
         self.name = 'file'
 
-    def get_actions(self) -> typing.Dict[str, ActionTable]:
-        actions = copy.copy(super().get_actions())
-        actions.update(_action_table)
-        return actions
+    def is_readable(self, path: Path) -> bool:
+        return readable(path)
 
+    def get_home(self) -> Path:
+        return Path.home()
 
-def check_output(view: View, cwd: str, args: typing.List[str]) -> None:
-    output = subprocess.check_output(args, cwd=cwd)
-    if output:
-        view.print_msg(output)
+    def path_maker(self, path: str) -> Path:
+        return Path(path)
 
+    def rmtree(self, path: Path) -> None:
+        shutil.rmtree(str(path))
 
-def check_overwrite(view: View, dest: Path, src: Path) -> Path:
-    if not src.exists() or not dest.exists():
-        return Path('')
+    def get_buffer_name(self, path: str) -> str:
+        return path
 
-    s_stat = src.stat()
-    s_mtime = s_stat.st_mtime
-    view.print_msg(f' src: {src} {s_stat.st_size} bytes')
-    view.print_msg(f'      {time.strftime("%c", time.localtime(s_mtime))}')
-    d_stat = dest.stat()
-    d_mtime = d_stat.st_mtime
-    view.print_msg(f'dest: {dest} {d_stat.st_size} bytes')
-    view.print_msg(f'      {time.strftime("%c", time.localtime(d_mtime))}')
-
-    choice: int = view._vim.call('defx#util#confirm',
-                                 f'{dest} already exists.  Overwrite?',
-                                 '&Force\n&No\n&Rename\n&Time\n&Underbar', 0)
-    ret: Path = Path('')
-    if choice == 1:
-        ret = dest
-    elif choice == 2:
-        ret = Path('')
-    elif choice == 3:
-        ret = Path(view._vim.call(
-            'defx#util#input',
-            f'{src} -> ', str(dest),
-            ('dir' if src.is_dir() else 'file')))
-    elif choice == 4 and d_mtime < s_mtime:
-        ret = src
-    elif choice == 5:
-        ret = Path(str(dest) + '_')
-    return ret
-
-
-def execute_job(view: View, args: typing.List[str]) -> None:
-    view._vim.call('defx#util#close_async_job')
-
-    if view._vim.call('has', 'nvim'):
-        jobfunc = 'jobstart'
-        jobopts = {}
-    else:
-        jobfunc = 'job_start'
-        jobopts = {'in_io': 'null', 'out_io': 'null', 'err_io': 'null'}
-
-    view._vim.vars['defx#_async_job'] = view._vim.call(jobfunc, args, jobopts)
-
-
-def switch(view: View) -> None:
-    windows = [x for x in range(1, view._vim.call('winnr', '$') + 1)
-               if view._vim.call('getwinvar', x, '&buftype') == '']
-
-    result = view._vim.call('choosewin#start', windows,
-                            {'auto_choose': True, 'hook_enable': False})
-    if not result:
-        # Open vertical
-        view._vim.command('noautocmd rightbelow vnew')
-
-
-@action(name='cd')
-def _cd(view: View, defx: Defx, context: Context) -> None:
-    """
-    Change the current directory.
-    """
-    source_name = defx._source.name
-    is_parent = context.args and context.args[0] == '..'
-    prev_cwd = Path(defx._cwd)
-
-    if is_parent:
-        path = prev_cwd.parent
-    else:
-        if context.args:
-            if len(context.args) > 1:
-                source_name = context.args[0]
-                path = Path(context.args[1])
-            else:
-                path = Path(context.args[0])
-        else:
-            path = Path.home()
-        path = prev_cwd.joinpath(path)
-        if not readable(path):
-            error(view._vim, f'{path} is invalid.')
-        path = path.resolve()
-        if source_name == 'file' and not path.is_dir():
-            error(view._vim, f'{path} is invalid.')
+    def preview_file(self, view: View, defx: Defx, context: Context,
+                     candidate: Candidate) -> None:
+        filepath = str(candidate['action__path'])
+        guess_type = mimetypes.guess_type(filepath)[0]
+        if (guess_type and guess_type.startswith('image/') and
+                shutil.which('ueberzug') and shutil.which('bash')):
+            self._preview_image(view, defx, context, candidate)
             return
 
-    view.cd(defx, source_name, str(path), context.cursor)
-    if is_parent:
-        view.search_file(prev_cwd, defx._index)
+        super().preview_file(view, defx, context, candidate)
 
-
-@action(name='change_vim_cwd', attr=ActionAttr.NO_TAGETS)
-def _change_vim_cwd(view: View, defx: Defx, context: Context) -> None:
-    """
-    Change the current working directory.
-    """
-    cd(view._vim, defx._cwd)
-
-
-@action(name='check_redraw', attr=ActionAttr.NO_TAGETS)
-def _check_redraw(view: View, defx: Defx, context: Context) -> None:
-    root = defx.get_root_candidate()['action__path']
-    if not root.exists():
-        return
-    mtime = root.stat().st_mtime
-    if mtime != defx._mtime:
-        view.redraw(True)
-
-
-@action(name='copy')
-def _copy(view: View, defx: Defx, context: Context) -> None:
-    if not context.targets:
-        return
-
-    message = 'Copy to the clipboard: {}'.format(
-        str(context.targets[0]['action__path'])
-        if len(context.targets) == 1
-        else str(len(context.targets)) + ' files')
-    view.print_msg(message)
-
-    view._clipboard.action = ClipboardAction.COPY
-    view._clipboard.candidates = context.targets
-    view._clipboard.source_name = 'file'
-
-
-@action(name='drop')
-def _drop(view: View, defx: Defx, context: Context) -> None:
-    """
-    Open like :drop.
-    """
-    cwd = view._vim.call('getcwd', -1)
-    command = context.args[0] if context.args else 'edit'
-
-    for target in context.targets:
-        path = target['action__path']
-
-        if path.is_dir():
-            view.cd(defx, defx._source.name, str(path), context.cursor)
-            continue
-
-        bufnr = view._vim.call('bufnr', f'^{path}$')
-        winids = view._vim.call('win_findbuf', bufnr)
-
-        if winids:
-            view._vim.call('win_gotoid', winids[0])
-        else:
-            # Jump to the last accessed window
-            view._vim.command('wincmd p')
-
-            if view._vim.call('win_getid') == view._winid:
-                view._vim.command('wincmd w')
-
-            if not view._vim.call('haslocaldir'):
-                try:
-                    path = path.relative_to(cwd)
-                except ValueError:
-                    pass
-
-            view._vim.call('defx#util#execute_path', command, str(path))
-
-        view.restore_previous_buffer(view._prev_bufnr)
-    view.close_preview()
-
-
-@action(name='execute_command', attr=ActionAttr.REDRAW)
-def _execute_command(view: View, defx: Defx, context: Context) -> None:
-    """
-    Execute the command.
-    """
-
-    command = (context.args[0]
-               if context.args and context.args[0]
-               else view._vim.call('defx#util#input',
-                                   'Command: ', '', 'shellcmd'))
-    if not command:
-        return
-    is_async = len(context.args) >= 2 and context.args[1] == 'async'
-
-    view._vim.command('redraw')
-
-    command_args = shlex.split(command)
-    if '*' in command_args:
-        args = []
-        for arg in command_args:
-            if arg == '*':
-                args += [str(x['action__path']) for x in context.targets]
-            else:
-                args.append(arg)
-
-        if is_async:
-            execute_job(view, args)
-        else:
-            check_output(view, defx._cwd, args)
-        return
-
-    def parse_argument(arg: str) -> str:
-        if not arg.startswith('%'):
-            return arg
-        arg = arg[1:]
-        m = re.match(r'((:.)*)(.*)', arg)
-        target_path = str(target['action__path'])
-        if not m:
-            return target_path
-        return fnamemodify(view._vim, target_path, m.group(2)) + m.group(3)
-
-    for target in context.targets:
-        args = [parse_argument(x) for x in command_args]
-
-        if is_async:
-            execute_job(view, args)
-        else:
-            check_output(view, defx._cwd, args)
-
-
-@action(name='execute_system')
-def _execute_system(view: View, defx: Defx, context: Context) -> None:
-    """
-    Execute the file by system associated command.
-    """
-    for target in context.targets:
-        view._vim.call('defx#util#open', str(target['action__path']))
-
-
-@action(name='link')
-def _link(view: View, defx: Defx, context: Context) -> None:
-    if not context.targets:
-        return
-
-    message = 'Link to the clipboard: {}'.format(
-        str(context.targets[0]['action__path'])
-        if len(context.targets) == 1
-        else str(len(context.targets)) + ' files')
-    view.print_msg(message)
-
-    view._clipboard.action = ClipboardAction.LINK
-    view._clipboard.candidates = context.targets
-    view._clipboard.source_name = 'file'
-
-
-@action(name='move')
-def _move(view: View, defx: Defx, context: Context) -> None:
-    if not context.targets:
-        return
-
-    message = 'Move to the clipboard: {}'.format(
-        str(context.targets[0]['action__path'])
-        if len(context.targets) == 1
-        else str(len(context.targets)) + ' files')
-    view.print_msg(message)
-
-    view._clipboard.action = ClipboardAction.MOVE
-    view._clipboard.candidates = context.targets
-    view._clipboard.source_name = 'file'
-
-
-@action(name='new_directory')
-def _new_directory(view: View, defx: Defx, context: Context) -> None:
-    """
-    Create a new directory.
-    """
-    candidate = view.get_cursor_candidate(context.cursor)
-    if not candidate:
-        return
-
-    if candidate['is_opened_tree'] or candidate['is_root']:
-        cwd = str(candidate['action__path'])
-    else:
-        cwd = str(Path(candidate['action__path']).parent)
-
-    new_filename = cwd_input(
-        view._vim, cwd,
-        'Please input a new directory name: ', '', 'file')
-    if not new_filename:
-        return
-    filename = Path(cwd).joinpath(new_filename)
-
-    if not filename:
-        return
-    if filename.exists():
-        error(view._vim, f'{filename} already exists')
-        return
-
-    filename.mkdir(parents=True)
-    view.redraw(True)
-    view.search_recursive(filename, defx._index)
-
-
-@action(name='new_file')
-def _new_file(view: View, defx: Defx, context: Context) -> None:
-    """
-    Create a new file and it's parent directories.
-    """
-    candidate = view.get_cursor_candidate(context.cursor)
-    if not candidate:
-        return
-
-    if candidate['is_opened_tree'] or candidate['is_root']:
-        cwd = str(candidate['action__path'])
-    else:
-        cwd = str(Path(candidate['action__path']).parent)
-
-    new_filename = cwd_input(
-        view._vim, cwd,
-        'Please input a new filename: ', '', 'file')
-    if not new_filename:
-        return
-    isdir = new_filename[-1] == '/'
-    filename = Path(cwd).joinpath(new_filename)
-
-    if not filename:
-        return
-    if filename.exists():
-        error(view._vim, f'{filename} already exists')
-        return
-
-    if isdir:
-        filename.mkdir(parents=True)
-    else:
-        filename.parent.mkdir(parents=True, exist_ok=True)
-        filename.touch()
-
-    view.redraw(True)
-    view.search_recursive(filename, defx._index)
-
-
-@action(name='new_multiple_files')
-def _new_multiple_files(view: View, defx: Defx, context: Context) -> None:
-    """
-    Create multiple files.
-    """
-    candidate = view.get_cursor_candidate(context.cursor)
-    if not candidate:
-        return
-
-    if candidate['is_opened_tree'] or candidate['is_root']:
-        cwd = str(candidate['action__path'])
-    else:
-        cwd = str(Path(candidate['action__path']).parent)
-
-    save_cwd = view._vim.call('getcwd')
-    cd(view._vim, cwd)
-
-    str_filenames: str = view._vim.call(
-        'input', 'Please input new filenames: ', '', 'file')
-    cd(view._vim, save_cwd)
-
-    if not str_filenames:
-        return None
-
-    for name in shlex.split(str_filenames):
-        is_dir = name[-1] == '/'
-
-        filename = Path(cwd).joinpath(name)
-        if filename.exists():
-            error(view._vim, f'{filename} already exists')
-            continue
-
-        if is_dir:
-            filename.mkdir(parents=True)
-        else:
-            if not filename.parent.exists():
-                filename.parent.mkdir(parents=True)
-            filename.touch()
-
-    view.redraw(True)
-    view.search_recursive(filename, defx._index)
-
-
-@action(name='open')
-def _open(view: View, defx: Defx, context: Context) -> None:
-    """
-    Open the file.
-    """
-    cwd = view._vim.call('getcwd', -1)
-    command = context.args[0] if context.args else 'edit'
-    choose = command == 'choose' and (
-        view._vim.call('exists', 'g:loaded_choosewin')
-        or view._vim.call('hasmapto', '<Plug>(choosewin)', 'n'))
-    previewed_buffers = view._vim.vars['defx#_previewed_buffers']
-    for target in context.targets:
-        path = target['action__path']
-
-        if path.is_dir():
-            view.cd(defx, defx._source.name, str(path), context.cursor)
-            continue
-
-        if not view._vim.call('haslocaldir'):
-            try:
-                path = path.relative_to(cwd)
-            except ValueError:
-                pass
-
-        if choose:
-            switch(view)
-
-        view._vim.call('defx#util#execute_path',
-                       'edit' if choose else command, str(path))
-
-        bufnr = str(view._vim.call('bufnr', str(path)))
-        if bufnr in previewed_buffers:
-            previewed_buffers.pop(bufnr)
-            view._vim.vars['defx#_previewed_buffers'] = previewed_buffers
-
-        view.restore_previous_buffer(view._prev_bufnr)
-    view.close_preview()
-
-
-@action(name='open_directory')
-def _open_directory(view: View, defx: Defx, context: Context) -> None:
-    """
-    Open the directory.
-    """
-    if context.args:
-        path = Path(context.args[0])
-    else:
-        for target in context.targets:
-            path = target['action__path']
-
-    if path.is_dir():
-        view.cd(defx, 'file', str(path), context.cursor)
-
-
-@action(name='paste', attr=ActionAttr.NO_TAGETS)
-def _paste(view: View, defx: Defx, context: Context) -> None:
-    candidate = view.get_cursor_candidate(context.cursor)
-    if not candidate:
-        return
-
-    if candidate['is_opened_tree'] or candidate['is_root']:
-        cwd = str(candidate['action__path'])
-    else:
-        cwd = str(Path(candidate['action__path']).parent)
-
-    action = view._clipboard.action
-    dest = None
-    for index, candidate in enumerate(view._clipboard.candidates):
-        path = candidate['action__path']
-        dest = Path(cwd).joinpath(path.name)
-        if dest.exists():
-            overwrite = check_overwrite(view, dest, path)
-            if overwrite == Path(''):
-                continue
-            dest = overwrite
-
-        if not path.exists() or path == dest:
-            continue
-
-        view.print_msg(
-            f'[{index + 1}/{len(view._clipboard.candidates)}] {path}')
-
-        if dest.exists() and action != ClipboardAction.MOVE:
-            # Must remove dest before
-            if not dest.is_symlink() and dest.is_dir():
-                shutil.rmtree(str(dest))
-            else:
-                dest.unlink()
-
+    def paste(self, view: View, src: Path, dest: Path,
+              cwd: str) -> None:
         if view._clipboard.source_name != 'file':
-            view._clipboard.paster(str(path), str(dest))
+            view._clipboard.paster(str(src), str(dest))
             view._vim.command('redraw')
-            continue
+            return
 
+        action = view._clipboard.action
         if action == ClipboardAction.COPY:
-            if path.is_dir():
-                shutil.copytree(str(path), dest)
+            if src.is_dir():
+                shutil.copytree(str(src), dest)
             else:
-                shutil.copy2(str(path), dest)
+                shutil.copy2(str(src), dest)
         elif action == ClipboardAction.MOVE:
-            shutil.move(str(path), cwd)
+            shutil.move(str(src), cwd)
 
             # Check rename
-            if not path.is_dir():
+            if not src.is_dir():
                 view._vim.call('defx#util#buffer_rename',
-                               view._vim.call('bufnr', str(path)), str(dest))
+                               view._vim.call('bufnr', str(src)), str(dest))
         elif action == ClipboardAction.LINK:
             # Create the symbolic link to dest
-            dest.symlink_to(path, target_is_directory=path.is_dir())
+            dest.symlink_to(src, target_is_directory=src.is_dir())
 
-        view._vim.command('redraw')
-    if action == ClipboardAction.MOVE:
-        # Clear clipboard after move
-        view._clipboard.candidates = []
-    view._vim.command('echo')
+    def check_output(self, view: View, cwd: str,
+                     args: typing.List[str]) -> None:
+        output = subprocess.check_output(args, cwd=cwd)
+        if output:
+            view.print_msg(output)
 
-    view.redraw(True)
-    if dest:
-        view.search_recursive(dest, defx._index)
+    @action(name='change_vim_cwd', attr=ActionAttr.NO_TAGETS)
+    def _change_vim_cwd(self, view: View, defx: Defx,
+                        context: Context) -> None:
+        """
+        Change the current working directory.
+        """
+        cd(view._vim, defx._cwd)
 
+    @action(name='execute_system')
+    def _execute_system(self, view: View, defx: Defx,
+                        context: Context) -> None:
+        """
+        Execute the file by system associated command.
+        """
+        for target in context.targets:
+            view._vim.call('defx#util#open', str(target['action__path']))
 
-@action(name='preview')
-def _preview(view: View, defx: Defx, context: Context) -> None:
-    candidate = view.get_cursor_candidate(context.cursor)
-    if not candidate or candidate['action__path'].is_dir():
-        return
-
-    filepath = str(candidate['action__path'])
-    guess_type = mimetypes.guess_type(filepath)[0]
-    if (guess_type and guess_type.startswith('image/') and
-            shutil.which('ueberzug') and shutil.which('bash')):
-        _preview_image(view, defx, context, candidate)
-        return
-
-    _preview_file(view, defx, context, candidate)
-
-
-def _preview_file(view: View, defx: Defx,
-                  context: Context, candidate: Candidate) -> None:
-    filepath = str(candidate['action__path'])
-
-    has_preview = bool(view._vim.call('defx#util#_get_preview_window'))
-    if (has_preview and view._previewed_target and
-            view._previewed_target == candidate):
-        view._vim.command('pclose!')
-        return
-
-    prev_id = view._vim.call('win_getid')
-
-    listed = view._vim.call('buflisted', filepath)
-
-    view._previewed_target = candidate
-    view._vim.call('defx#util#preview_file',
-                   context._replace(targets=[])._asdict(), filepath)
-    view._vim.current.window.options['foldenable'] = False
-
-    if not listed:
-        bufnr = str(view._vim.call('bufnr', filepath))
-        previewed_buffers = view._vim.vars['defx#_previewed_buffers']
-        previewed_buffers[bufnr] = 1
-        view._vim.vars['defx#_previewed_buffers'] = previewed_buffers
-
-    view._vim.call('win_gotoid', prev_id)
-
-
-def _preview_image(view: View, defx: Defx,
-                   context: Context, candidate: Candidate) -> None:
-    filepath = str(candidate['action__path'])
-
-    if filepath == view._previewed_img:
-        view._previewed_img = ''
-        return
-
-    preview_image_sh = Path(__file__).parent.parent.joinpath(
-        'preview_image.sh')
-
-    wincol = context.wincol + view._vim.call('winwidth', 0)
-    if wincol + context.preview_width > view._vim.options['columns']:
-        wincol -= 2 * context.preview_width
-    args = ['bash', str(preview_image_sh), filepath,
-            wincol, 1, context.preview_width]
-
-    execute_job(view, args)
-    view._previewed_img = filepath
-
-
-@action(name='remove', attr=ActionAttr.REDRAW)
-def _remove(view: View, defx: Defx, context: Context) -> None:
-    """
-    Delete the file or directory.
-    """
-    if not context.targets:
-        return
-
-    force = context.args[0] == 'force' if context.args else False
-    if not force:
-        message = 'Are you sure you want to delete {}?'.format(
-            str(context.targets[0]['action__path'])
-            if len(context.targets) == 1
-            else str(len(context.targets)) + ' files')
-        if not confirm(view._vim, message):
+    @action(name='preview')
+    def _preview(self, view: View, defx: Defx, context: Context) -> None:
+        candidate = view.get_cursor_candidate(context.cursor)
+        if not candidate or candidate['action__path'].is_dir():
             return
 
-    for target in context.targets:
-        path = target['action__path']
-
-        if path.is_dir():
-            shutil.rmtree(str(path))
-        else:
-            path.unlink()
-
-        view._vim.call('defx#util#buffer_delete',
-                       view._vim.call('bufnr', str(path)))
-
-
-@action(name='remove_trash', attr=ActionAttr.REDRAW)
-def _remove_trash(view: View, defx: Defx, context: Context) -> None:
-    """
-    Delete the file or directory.
-    """
-    if not context.targets:
-        return
-
-    if not importlib.util.find_spec('send2trash'):
-        error(view._vim, '"Send2Trash" is not installed')
-        return
-
-    force = context.args[0] == 'force' if context.args else False
-    if not force:
-        message = 'Are you sure you want to delete {}?'.format(
-            str(context.targets[0]['action__path'])
-            if len(context.targets) == 1
-            else str(len(context.targets)) + ' files')
-        if not confirm(view._vim, message):
+        filepath = str(candidate['action__path'])
+        guess_type = mimetypes.guess_type(filepath)[0]
+        if (guess_type and guess_type.startswith('image/') and
+                shutil.which('ueberzug') and shutil.which('bash')):
+            self._preview_image(view, defx, context, candidate)
             return
 
-    import send2trash
-    for target in context.targets:
-        send2trash.send2trash(str(target['action__path']))
+        self.preview_file(view, defx, context, candidate)
 
-        view._vim.call('defx#util#buffer_delete',
-                       view._vim.call('bufnr', str(target['action__path'])))
+    def _preview_image(self, view: View, defx: Defx,
+                       context: Context, candidate: Candidate) -> None:
+        filepath = str(candidate['action__path'])
 
-
-@action(name='rename')
-def _rename(view: View, defx: Defx, context: Context) -> None:
-    """
-    Rename the file or directory.
-    """
-
-    if len(context.targets) > 1:
-        # ex rename
-        view._vim.call('defx#exrename#create_buffer',
-                       [{'action__path': str(x['action__path'])}
-                        for x in context.targets],
-                       {'buffer_name': 'defx'})
-        return
-
-    for target in context.targets:
-        old = target['action__path']
-        new_filename = cwd_input(
-            view._vim, defx._cwd,
-            f'Old name: {old}\nNew name: ', str(old), 'file')
-        view._vim.command('redraw')
-        if not new_filename:
+        if filepath == view._previewed_img:
+            view._previewed_img = ''
             return
-        new = Path(defx._cwd).joinpath(new_filename)
-        if not new or new == old:
-            continue
-        if str(new).lower() != str(old).lower() and new.exists():
-            error(view._vim, f'{new} already exists')
-            continue
 
-        if not new.parent.exists():
-            new.parent.mkdir(parents=True)
-        old.rename(new)
+        preview_image_sh = Path(__file__).parent.parent.joinpath(
+            'preview_image.sh')
 
-        # Check rename
-        # The old is directory, the path may be matched opened file
-        if not new.is_dir():
-            view._vim.call('defx#util#buffer_rename',
-                           view._vim.call('bufnr', str(old)), str(new))
+        wincol = context.wincol + view._vim.call('winwidth', 0)
+        if wincol + context.preview_width > view._vim.options['columns']:
+            wincol -= 2 * context.preview_width
+        args = ['bash', str(preview_image_sh), filepath,
+                wincol, 1, context.preview_width]
 
-        view.redraw(True)
-        view.search_recursive(new, defx._index)
+        self.execute_job(view, args)
+        view._previewed_img = filepath
+
+    @action(name='remove_trash', attr=ActionAttr.REDRAW)
+    def _remove_trash(self, view: View, defx: Defx, context: Context) -> None:
+        """
+        Delete the file or directory.
+        """
+        if not context.targets:
+            return
+
+        if not importlib.util.find_spec('send2trash'):
+            error(view._vim, '"Send2Trash" is not installed')
+            return
+
+        force = context.args[0] == 'force' if context.args else False
+        if not force:
+            message = 'Are you sure you want to delete {}?'.format(
+                str(context.targets[0]['action__path'])
+                if len(context.targets) == 1
+                else str(len(context.targets)) + ' files')
+            if not confirm(view._vim, message):
+                return
+
+        import send2trash
+        for target in context.targets:
+            send2trash.send2trash(str(target['action__path']))
+
+            view._vim.call(
+                'defx#util#buffer_delete',
+                view._vim.call('bufnr', str(target['action__path'])))

--- a/rplugin/python3/defx/kind/filelike.py
+++ b/rplugin/python3/defx/kind/filelike.py
@@ -62,7 +62,8 @@ class Kind(Base):
         '''
         pass
 
-    def paste(self, view: View, src: PathLike, dest: PathLike) -> None:
+    def paste(self, view: View, src: PathLike, dest: PathLike,
+              cwd: str) -> None:
         pass
 
     def preview_file(self, view: View, defx: Defx,
@@ -82,7 +83,7 @@ class Kind(Base):
         view._previewed_target = candidate
         view._vim.call('defx#util#preview_file',
                        context._replace(targets=[])._asdict(),
-                       self.get_buffer_name(str(filepath)))
+                       self.get_buffer_name(filepath))
         view._vim.current.window.options['foldenable'] = False
 
         if not listed:
@@ -224,7 +225,6 @@ class Kind(Base):
         view._clipboard.action = ClipboardAction.COPY
         view._clipboard.candidates = context.targets
         view._clipboard.source_name = defx._source.name
-        view._clipboard.paster = self.paste_to_local
 
     @action(name='drop')
     def _drop(self, view: View, defx: Defx, context: Context) -> None:
@@ -540,7 +540,7 @@ class Kind(Base):
                 else:
                     dest.unlink()
 
-            self.paste(view, path, dest)
+            self.paste(view, path, dest, cwd)
             view._vim.command('redraw')
         if action == ClipboardAction.MOVE:
             # Clear clipboard after move

--- a/rplugin/python3/defx/kind/filelike.py
+++ b/rplugin/python3/defx/kind/filelike.py
@@ -22,10 +22,8 @@ from defx.util import cwd_input, confirm, error, Candidate
 from defx.util import fnamemodify
 from defx.view import View
 
-ACTION_FUNC = typing.Callable[[View, Defx, Context], None]
 
-
-PathLike = typing.NewType('PathLike', Path)
+PathLike = typing.Union[Path, typing.Any]
 
 
 class Kind(Base):

--- a/rplugin/python3/defx/kind/filelike.py
+++ b/rplugin/python3/defx/kind/filelike.py
@@ -1,0 +1,672 @@
+# ============================================================================
+# FILE: filelike.py
+# AUTHOR: Shougo Matsushita <Shougo.Matsu at gmail.com>
+#         Haruki Matsui <haru.matu9168 at gmail.com>
+# License: MIT license
+# ============================================================================
+
+from pathlib import Path
+from pynvim import Nvim
+import copy
+import shlex
+import shutil
+import subprocess
+import re
+import time
+import typing
+
+from defx.action import ActionAttr
+from defx.action import ActionTable
+from defx.base.kind import Base
+from defx.clipboard import ClipboardAction
+from defx.context import Context
+from defx.defx import Defx
+from defx.util import cwd_input, confirm, error, Candidate
+from defx.util import fnamemodify
+from defx.view import View
+
+_action_table: typing.Dict[str, ActionTable] = {}
+
+ACTION_FUNC = typing.Callable[[View, Defx, Context], None]
+
+
+PathLike = typing.NewType('PathLike', Path)
+
+
+def action(name: str, attr: ActionAttr = ActionAttr.NONE
+           ) -> typing.Callable[[ACTION_FUNC], ACTION_FUNC]:
+    def wrapper(func: ACTION_FUNC) -> ACTION_FUNC:
+        _action_table[name] = ActionTable(func=func, attr=attr)
+
+        def inner_wrapper(view: View, defx: Defx, context: Context) -> None:
+            return func(view, defx, context)
+        return inner_wrapper
+    return wrapper
+
+
+class Kind(Base):
+    """ Abstract class which handles filelike objects kind.
+
+    External kinds can inherit this class and use/override methods.
+    """
+
+    def __init__(self, vim: Nvim) -> None:
+        self.vim = vim
+        self.name = 'filelike'
+
+    def get_actions(self) -> typing.Dict[str, ActionTable]:
+        actions = copy.copy(super().get_actions())
+        actions.update(_action_table)
+        return actions
+
+    def is_readable(self, path: PathLike) -> bool:
+        pass
+
+    def get_home(self) -> PathLike:
+        pass
+
+    def path_maker(self, path: str) -> PathLike:
+        """
+        Create PathLike object from string and returns it
+        """
+        pass
+
+    def rmtree(self, path: PathLike) -> None:
+        pass
+
+    def get_buffer_name(self, path: str) -> str:
+        '''
+        Returns the buffer name when opening files in Vim buffer.
+        Example:
+             >>> self.get_buffer_name('/remote/path')
+                ssh://usr@host/remote/path
+        '''
+        pass
+
+    def preview_file(self, view: View, defx: Defx,
+                     context: Context, candidate: Candidate) -> None:
+        filepath = str(candidate['action__path'])
+
+        has_preview = bool(view._vim.call('defx#util#_get_preview_window'))
+        if (has_preview and view._previewed_target and
+                view._previewed_target == candidate):
+            view._vim.command('pclose!')
+            return
+
+        prev_id = view._vim.call('win_getid')
+
+        listed = view._vim.call('buflisted', filepath)
+
+        view._previewed_target = candidate
+        view._vim.call('defx#util#preview_file',
+                       context._replace(targets=[])._asdict(),
+                       self.get_buffer_name(str(filepath)))
+        view._vim.current.window.options['foldenable'] = False
+
+        if not listed:
+            bufnr = str(view._vim.call('bufnr', filepath))
+            previewed_buffers = view._vim.vars['defx#_previewed_buffers']
+            previewed_buffers[bufnr] = 1
+            view._vim.vars['defx#_previewed_buffers'] = previewed_buffers
+
+        view._vim.call('win_gotoid', prev_id)
+
+    def input(self, view: View, defx: Defx, cwd: str, prompt: str, text: str,
+              completion: str) -> str:
+        if defx._source.name == 'file':
+            res = cwd_input(
+                view._vim, cwd,
+                prompt, text, completion)
+        else:
+            res = str(view._vim.call(
+                'defx#util#input',
+                prompt, text, completion))
+        return res
+
+    def check_output(self, view: View, cwd: str,
+                     args: typing.List[str]) -> None:
+        output = subprocess.check_output(args, cwd=cwd)
+        if output:
+            view.print_msg(output)
+
+    def check_overwrite(self, view: View,
+                        dest: PathLike, src: PathLike) -> PathLike:
+        if not src.exists() or not dest.exists():
+            return self.path_maker('')
+
+        s_stat = src.stat()
+        s_mtime = s_stat.st_mtime
+        view.print_msg(f' src: {src} {s_stat.st_size} bytes')
+        view.print_msg(f'      {time.strftime("%c", time.localtime(s_mtime))}')
+        d_stat = dest.stat()
+        d_mtime = d_stat.st_mtime
+        view.print_msg(f'dest: {dest} {d_stat.st_size} bytes')
+        view.print_msg(f'      {time.strftime("%c", time.localtime(d_mtime))}')
+
+        choice: int = view._vim.call(
+            'defx#util#confirm',
+            f'{dest} already exists.  Overwrite?',
+            '&Force\n&No\n&Rename\n&Time\n&Underbar', 0)
+
+        ret: PathLike = self.path_maker('')
+        if choice == 1:
+            ret = dest
+        elif choice == 2:
+            ret = self.path_maker('')
+        elif choice == 3:
+            ret = self.path_maker(view._vim.call(
+                'defx#util#input',
+                f'{src} -> ', str(dest),
+                ('dir' if src.is_dir() else 'file')))
+        elif choice == 4 and d_mtime < s_mtime:
+            ret = src
+        elif choice == 5:
+            ret = self.path_maker(str(dest) + '_')
+        return ret
+
+    def execute_job(self, view: View, args: typing.List[str]) -> None:
+        view._vim.call('defx#util#close_async_job')
+
+        if view._vim.call('has', 'nvim'):
+            jobfunc = 'jobstart'
+            jobopts = {}
+        else:
+            jobfunc = 'job_start'
+            jobopts = {'in_io': 'null', 'out_io': 'null', 'err_io': 'null'}
+
+        view._vim.vars['defx#_async_job'] = view._vim.call(
+            jobfunc, args, jobopts)
+
+    def switch(self, view: View) -> None:
+        windows = [x for x in range(1, view._vim.call('winnr', '$') + 1)
+                   if view._vim.call('getwinvar', x, '&buftype') == '']
+
+        result = view._vim.call('choosewin#start', windows,
+                                {'auto_choose': True, 'hook_enable': False})
+        if not result:
+            # Open vertical
+            view._vim.command('noautocmd rightbelow vnew')
+
+    @action(name='cd')
+    def _cd(self, view: View, defx: Defx, context: Context) -> None:
+        """
+        Change the current directory.
+        """
+        source_name = defx._source.name
+        is_parent = context.args and context.args[0] == '..'
+        prev_cwd = self.path_maker(defx._cwd)
+
+        if is_parent:
+            path = prev_cwd.parent
+        else:
+            if context.args:
+                if len(context.args) > 1:
+                    source_name = context.args[0]
+                    path = self.path_maker(context.args[1])
+                else:
+                    path = self.path_maker(context.args[0])
+            else:
+                path = self.get_home()
+            path = prev_cwd.joinpath(path)
+            if not self.is_readable(path):
+                error(view._vim, f'{path} is invalid.')
+            path = path.resolve()
+            if source_name == 'file' and not path.is_dir():
+                error(view._vim, f'{path} is invalid.')
+                return
+
+        view.cd(defx, source_name, str(path), context.cursor)
+        if is_parent:
+            view.search_file(prev_cwd, defx._index)
+
+    @action(name='check_redraw', attr=ActionAttr.NO_TAGETS)
+    def _check_redraw(self, view: View, defx: Defx, context: Context) -> None:
+        root = defx.get_root_candidate()['action__path']
+        if not root.exists():
+            return
+        mtime = root.stat().st_mtime
+        if mtime != defx._mtime:
+            view.redraw(True)
+
+    @action(name='copy')
+    def _copy(self, view: View, defx: Defx, context: Context) -> None:
+        if not context.targets:
+            return
+
+        message = 'Copy to the clipboard: {}'.format(
+            str(context.targets[0]['action__path'])
+            if len(context.targets) == 1
+            else str(len(context.targets)) + ' files')
+        view.print_msg(message)
+
+        view._clipboard.action = ClipboardAction.COPY
+        view._clipboard.candidates = context.targets
+        view._clipboard.source_name = defx._source.name
+        # TODO: define paster
+
+    @action(name='drop')
+    def _drop(self, view: View, defx: Defx, context: Context) -> None:
+        """
+        Open like :drop.
+        """
+        cwd = view._vim.call('getcwd', -1)
+        command = context.args[0] if context.args else 'edit'
+
+        for target in context.targets:
+            path = target['action__path']
+
+            if path.is_dir():
+                view.cd(defx, defx._source.name, str(path), context.cursor)
+                continue
+
+            bufnr = view._vim.call('bufnr', f'^{path}$')
+            winids = view._vim.call('win_findbuf', bufnr)
+
+            if winids:
+                view._vim.call('win_gotoid', winids[0])
+            else:
+                # Jump to the last accessed window
+                view._vim.command('wincmd p')
+
+                if view._vim.call('win_getid') == view._winid:
+                    view._vim.command('wincmd w')
+
+                if not view._vim.call('haslocaldir'):
+                    try:
+                        path = path.relative_to(cwd)
+                    except ValueError:
+                        pass
+
+                view._vim.call('defx#util#execute_path', command,
+                               self.get_buffer_name(str(path)))
+
+            view.restore_previous_buffer(view._prev_bufnr)
+        view.close_preview()
+
+    @action(name='execute_command', attr=ActionAttr.REDRAW)
+    def _execute_command(self, view: View, defx: Defx,
+                         context: Context) -> None:
+        """
+        Execute the command.
+        """
+
+        command = (context.args[0]
+                   if context.args and context.args[0]
+                   else view._vim.call('defx#util#input',
+                                       'Command: ', '', 'shellcmd'))
+        if not command:
+            return
+        is_async = len(context.args) >= 2 and context.args[1] == 'async'
+
+        view._vim.command('redraw')
+
+        command_args = shlex.split(command)
+        if '*' in command_args:
+            args = []
+            for arg in command_args:
+                if arg == '*':
+                    args += [str(x['action__path']) for x in context.targets]
+                else:
+                    args.append(arg)
+
+            if is_async:
+                self.execute_job(view, args)
+            else:
+                self.check_output(view, defx._cwd, args)
+            return
+
+        def parse_argument(arg: str) -> str:
+            if not arg.startswith('%'):
+                return arg
+            arg = arg[1:]
+            m = re.match(r'((:.)*)(.*)', arg)
+            target_path = str(target['action__path'])
+            if not m:
+                return target_path
+            return fnamemodify(view._vim, target_path, m.group(2)) + m.group(3)
+
+        for target in context.targets:
+            args = [parse_argument(x) for x in command_args]
+
+            if is_async:
+                self.execute_job(view, args)
+            else:
+                self.check_output(view, defx._cwd, args)
+
+    @action(name='link')
+    def _link(self, view: View, defx: Defx, context: Context) -> None:
+        if not context.targets:
+            return
+
+        message = 'Link to the clipboard: {}'.format(
+            str(context.targets[0]['action__path'])
+            if len(context.targets) == 1
+            else str(len(context.targets)) + ' files')
+        view.print_msg(message)
+
+        view._clipboard.action = ClipboardAction.LINK
+        view._clipboard.candidates = context.targets
+        view._clipboard.source_name = defx._source.name
+        # TODO: define paster
+
+    @action(name='move')
+    def _move(self, view: View, defx: Defx, context: Context) -> None:
+        if not context.targets:
+            return
+
+        message = 'Move to the clipboard: {}'.format(
+            str(context.targets[0]['action__path'])
+            if len(context.targets) == 1
+            else str(len(context.targets)) + ' files')
+        view.print_msg(message)
+
+        view._clipboard.action = ClipboardAction.MOVE
+        view._clipboard.candidates = context.targets
+        view._clipboard.source_name = defx._source.name
+        # TODO: define paster
+
+    @action(name='new_directory')
+    def _new_directory(self, view: View, defx: Defx, context: Context) -> None:
+        """
+        Create a new directory.
+        """
+        candidate = view.get_cursor_candidate(context.cursor)
+        if not candidate:
+            return
+
+        if candidate['is_opened_tree'] or candidate['is_root']:
+            cwd = str(candidate['action__path'])
+        else:
+            cwd = str(Path(candidate['action__path']).parent)
+
+        new_filename = self.input(
+            view, defx, cwd, 'Please input a new directory name: ', '', 'file')
+        if not new_filename:
+            return
+        filename = self.path_maker(cwd).joinpath(new_filename)
+
+        if not filename:
+            return
+        if filename.exists():
+            error(view._vim, f'{filename} already exists')
+            return
+
+        filename.mkdir(parents=True)
+        view.redraw(True)
+        view.search_recursive(filename, defx._index)
+
+    @action(name='new_file')
+    def _new_file(self, view: View, defx: Defx, context: Context) -> None:
+        """
+        Create a new file and it's parent directories.
+        """
+        candidate = view.get_cursor_candidate(context.cursor)
+        if not candidate:
+            return
+
+        if candidate['is_opened_tree'] or candidate['is_root']:
+            cwd = str(candidate['action__path'])
+        else:
+            cwd = str(Path(candidate['action__path']).parent)
+
+        new_filename = self.input(
+            view, defx, cwd, 'Please input a new filename: ', '', 'file')
+        if not new_filename:
+            return
+        isdir = new_filename[-1] == '/'
+        filename = self.path_maker(cwd).joinpath(new_filename)
+
+        if not filename:
+            return
+        if filename.exists():
+            error(view._vim, f'{filename} already exists')
+            return
+
+        if isdir:
+            filename.mkdir(parents=True)
+        else:
+            filename.parent.mkdir(parents=True, exist_ok=True)
+            filename.touch()
+
+        view.redraw(True)
+        view.search_recursive(filename, defx._index)
+
+    @action(name='new_multiple_files')
+    def _new_multiple_files(self, view: View, defx: Defx,
+                            context: Context) -> None:
+        """
+        Create multiple files.
+        """
+        candidate = view.get_cursor_candidate(context.cursor)
+        if not candidate:
+            return
+
+        if candidate['is_opened_tree'] or candidate['is_root']:
+            cwd = str(candidate['action__path'])
+        else:
+            cwd = str(Path(candidate['action__path']).parent)
+
+        str_filenames = self.input(
+            view, defx, cwd,
+            'Please input new filenames: ', '', 'file')
+
+        if not str_filenames:
+            return None
+
+        for name in shlex.split(str_filenames):
+            is_dir = name[-1] == '/'
+
+            filename = self.path_maker(cwd).joinpath(name)
+            if filename.exists():
+                error(view._vim, f'{filename} already exists')
+                continue
+
+            if is_dir:
+                filename.mkdir(parents=True)
+            else:
+                if not filename.parent.exists():
+                    filename.parent.mkdir(parents=True)
+                filename.touch()
+
+        view.redraw(True)
+        view.search_recursive(filename, defx._index)
+
+    @action(name='open')
+    def _open(self, view: View, defx: Defx, context: Context) -> None:
+        """
+        Open the file.
+        """
+        cwd = view._vim.call('getcwd', -1)
+        command = context.args[0] if context.args else 'edit'
+        choose = command == 'choose' and (
+            view._vim.call('exists', 'g:loaded_choosewin')
+            or view._vim.call('hasmapto', '<Plug>(choosewin)', 'n'))
+        previewed_buffers = view._vim.vars['defx#_previewed_buffers']
+        for target in context.targets:
+            path = target['action__path']
+
+            if path.is_dir():
+                view.cd(defx, defx._source.name, str(path), context.cursor)
+                continue
+
+            if not view._vim.call('haslocaldir'):
+                try:
+                    path = path.relative_to(cwd)
+                except ValueError:
+                    pass
+
+            if choose:
+                self.switch(view)
+
+            view._vim.call('defx#util#execute_path',
+                           'edit' if choose else command,
+                           self.get_buffer_name(str(path)))
+
+            bufnr = str(view._vim.call('bufnr', str(path)))
+            if bufnr in previewed_buffers:
+                previewed_buffers.pop(bufnr)
+                view._vim.vars['defx#_previewed_buffers'] = previewed_buffers
+
+            view.restore_previous_buffer(view._prev_bufnr)
+        view.close_preview()
+
+    @action(name='open_directory')
+    def _open_directory(self, view: View, defx: Defx,
+                        context: Context) -> None:
+        """
+        Open the directory.
+        """
+        if context.args:
+            path = self.path_maker(context.args[0])
+        else:
+            for target in context.targets:
+                path = target['action__path']
+
+        if path.is_dir():
+            view.cd(defx, 'file', str(path), context.cursor)
+
+    @action(name='paste', attr=ActionAttr.NO_TAGETS)
+    def _paste(self, view: View, defx: Defx, context: Context) -> None:
+        candidate = view.get_cursor_candidate(context.cursor)
+        if not candidate:
+            return
+
+        if candidate['is_opened_tree'] or candidate['is_root']:
+            cwd = str(candidate['action__path'])
+        else:
+            cwd = str(Path(candidate['action__path']).parent)
+
+        action = view._clipboard.action
+        dest = None
+        for index, candidate in enumerate(view._clipboard.candidates):
+            path = candidate['action__path']
+            dest = self.path_maker(cwd).joinpath(path.name)
+            if dest.exists():
+                overwrite = self.check_overwrite(view, dest, path)
+                if overwrite == self.path_maker(''):
+                    continue
+                dest = overwrite
+
+            if not path.exists() or path == dest:
+                continue
+
+            view.print_msg(
+                f'[{index + 1}/{len(view._clipboard.candidates)}] {path}')
+
+            if dest.exists() and action != ClipboardAction.MOVE:
+                # Must remove dest before
+                if not dest.is_symlink() and dest.is_dir():
+                    self.rmtree(dest)
+                else:
+                    dest.unlink()
+
+            # TODO
+            if view._clipboard.source_name != 'file':
+                view._clipboard.paster(str(path), str(dest))
+                view._vim.command('redraw')
+                continue
+
+            if action == ClipboardAction.COPY:
+                if path.is_dir():
+                    shutil.copytree(str(path), dest)
+                else:
+                    shutil.copy2(str(path), dest)
+            elif action == ClipboardAction.MOVE:
+                shutil.move(str(path), cwd)
+
+                # Check rename
+                if not path.is_dir():
+                    view._vim.call(
+                        'defx#util#buffer_rename',
+                        view._vim.call('bufnr', str(path)), str(dest))
+            elif action == ClipboardAction.LINK:
+                # Create the symbolic link to dest
+                dest.symlink_to(path, target_is_directory=path.is_dir())
+
+            view._vim.command('redraw')
+        if action == ClipboardAction.MOVE:
+            # Clear clipboard after move
+            view._clipboard.candidates = []
+        view._vim.command('echo')
+
+        view.redraw(True)
+        if dest:
+            view.search_recursive(dest, defx._index)
+
+    @action(name='preview')
+    def _preview(self, view: View, defx: Defx, context: Context) -> None:
+        candidate = view.get_cursor_candidate(context.cursor)
+        if not candidate or candidate['action__path'].is_dir():
+            return
+
+        self.preview_file(view, defx, context, candidate)
+
+    @action(name='remove', attr=ActionAttr.REDRAW)
+    def _remove(self, view: View, defx: Defx, context: Context) -> None:
+        """
+        Delete the file or directory.
+        """
+        if not context.targets:
+            return
+
+        force = context.args[0] == 'force' if context.args else False
+        if not force:
+            message = 'Are you sure you want to delete {}?'.format(
+                str(context.targets[0]['action__path'])
+                if len(context.targets) == 1
+                else str(len(context.targets)) + ' files')
+            if not confirm(view._vim, message):
+                return
+
+        for target in context.targets:
+            path = target['action__path']
+
+            if path.is_dir():
+                self.rmtree(path)
+            else:
+                path.unlink()
+
+            view._vim.call('defx#util#buffer_delete',
+                           view._vim.call('bufnr', str(path)))
+
+    @action(name='rename')
+    def _rename(self, view: View, defx: Defx, context: Context) -> None:
+        """
+        Rename the file or directory.
+        """
+
+        if len(context.targets) > 1:
+            # ex rename
+            view._vim.call('defx#exrename#create_buffer',
+                           [{'action__path': str(x['action__path'])}
+                            for x in context.targets],
+                           {'buffer_name': 'defx'})
+            return
+
+        for target in context.targets:
+            old = target['action__path']
+            new_filename = self.input(
+                view, defx, defx._cwd,
+                f'Old name: {old}\nNew name: ', str(old), 'file')
+            view._vim.command('redraw')
+            if not new_filename:
+                return
+            new = self.path_maker(defx._cwd).joinpath(new_filename)
+            if not new or new == old:
+                continue
+            if str(new).lower() != str(old).lower() and new.exists():
+                error(view._vim, f'{new} already exists')
+                continue
+
+            if not new.parent.exists():
+                new.parent.mkdir(parents=True)
+            old.rename(new)
+
+            # Check rename
+            # The old is directory, the path may be matched opened file
+            if not new.is_dir():
+                view._vim.call('defx#util#buffer_rename',
+                               view._vim.call('bufnr', str(old)), str(new))
+
+            view.redraw(True)
+            view.search_recursive(new, defx._index)

--- a/rplugin/python3/defx/kind/filelike.py
+++ b/rplugin/python3/defx/kind/filelike.py
@@ -7,7 +7,6 @@
 
 from pathlib import Path
 from pynvim import Nvim
-import copy
 import shlex
 import subprocess
 import re
@@ -15,8 +14,7 @@ import time
 import typing
 
 from defx.action import ActionAttr
-from defx.action import ActionTable
-from defx.base.kind import Base
+from defx.base.kind import Base, action
 from defx.clipboard import ClipboardAction
 from defx.context import Context
 from defx.defx import Defx
@@ -24,23 +22,10 @@ from defx.util import cwd_input, confirm, error, Candidate
 from defx.util import fnamemodify
 from defx.view import View
 
-_action_table: typing.Dict[str, ActionTable] = {}
-
 ACTION_FUNC = typing.Callable[[View, Defx, Context], None]
 
 
 PathLike = typing.NewType('PathLike', Path)
-
-
-def action(name: str, attr: ActionAttr = ActionAttr.NONE
-           ) -> typing.Callable[[ACTION_FUNC], ACTION_FUNC]:
-    def wrapper(func: ACTION_FUNC) -> ACTION_FUNC:
-        _action_table[name] = ActionTable(func=func, attr=attr)
-
-        def inner_wrapper(view: View, defx: Defx, context: Context) -> None:
-            return func(view, defx, context)
-        return inner_wrapper
-    return wrapper
 
 
 class Kind(Base):
@@ -52,11 +37,6 @@ class Kind(Base):
     def __init__(self, vim: Nvim) -> None:
         self.vim = vim
         self.name = 'filelike'
-
-    def get_actions(self) -> typing.Dict[str, ActionTable]:
-        actions = copy.copy(super().get_actions())
-        actions.update(_action_table)
-        return actions
 
     def is_readable(self, path: PathLike) -> bool:
         pass


### PR DESCRIPTION
## Problem
When creating sources and kinds in `defx/kind/*.py`, I must write a lot of code which is the same as `defx/kind/file.py`.
For example, [here](https://github.com/matsui54/defx-sftp/blob/b58059f687d9f5d9e13b10ed43e9925ddeae6b27/rplugin/python3/defx/kind/sftp.py) is the definition of actions in [defx-sftp](https://github.com/matsui54/defx-sftp).
Though most of the code is the same as `kind/file.py`, some actions must be redefined for `SFTPPath`.
This duplication of code makes it difficult to maintain external sources.

## Expected behaviour
User-defined kinds can be written in the following way.
- Users send objects which has the same methods as `pathlib.Path` like `is_dir()` or `mkdir()` as candidates in `get_root_candidate()` and `get_root_candidate()` in `source/*.py`
  This can be done like [this `SFTPPath`](https://github.com/matsui54/defx-sftp/blob/b58059f687d9f5d9e13b10ed43e9925ddeae6b27/rplugin/python3/defx/sftp/sftp_path.py)
  This will enable external sources to use the same code as `file` kind.
- As for `kind/*.py`, users can inherit filelike Kind, which has the basic functions for handling not only local files but also remote ones.
  Users can override some of the method in filelike Kind as needed.

## Things to be changed
This PR will include following changes.
- Create filelike kind.
- Define actions as methods of each Kind class.
  - This is because users can easily override filelike kind's methods including the utility functions like `get_home()` or `path_maker()`.
- Make file kind inherit filelike kind.
