### PR TITLE
Add space before filename

### DIFF
--- a/rplugin/python3/defx/column/filename.py
+++ b/rplugin/python3/defx/column/filename.py
@@ -62,6 +62,9 @@ class Column(Base):
                 highlights = [(f'{self.highlight_name}_directory',
                                self.start, len_bytes(candidate['word']))]
 
+        # add padding between columns
+        if text and text[-1] != ' ':
+            text += ' '
         text += candidate['word']
         return (self._truncate(text), highlights)
 


### PR DESCRIPTION
By commit c27b4c93fd117dcfec24894d30aeca0acdfb61c9, space between icon(s) and filename is removed while the padding is added to between other columns.
![defx_padding_bug](https://user-images.githubusercontent.com/63794197/125763996-5601b109-2024-4474-8050-0fa088cb1906.png)